### PR TITLE
Project table

### DIFF
--- a/app/Http/Controllers/Admin/Operations/AssessOperation.php
+++ b/app/Http/Controllers/Admin/Operations/AssessOperation.php
@@ -46,7 +46,7 @@ trait AssessOperation
         });
 
         $this->crud->operation('list', function () {
-            $this->crud->addButton('line', 'assess', 'view', 'crud::buttons.assess')->before('update');
+            $this->crud->addButton('line', 'assess', 'view', 'crud::buttons.assess')->makeFirst();
         });
 
         $this->crud->setupDefaultSaveActions();
@@ -130,7 +130,7 @@ trait AssessOperation
             if ($custom_score_tags) {
 
                 for ($i = 0, $iMax = count($custom_score_tags); $i < $iMax; $i++) {
-                    
+
                     if (empty($custom_score_tags[$i])){
                         unset($custom_score_tags[$i]);
                     }
@@ -142,7 +142,7 @@ trait AssessOperation
                     else {
                         $custom_score_tags[$i]['project_id'] = $project->id;
                     }
-                    
+
                 }
 
                 $principleProject->customScoreTags()->createMany($custom_score_tags);

--- a/app/Http/Controllers/Admin/Operations/RedlineOperation.php
+++ b/app/Http/Controllers/Admin/Operations/RedlineOperation.php
@@ -48,7 +48,7 @@ trait RedlineOperation
 
         $this->crud->operation('list', function () {
             // $this->crud->addButton('top', 'assess', 'view', 'crud::buttons.assess');
-            $this->crud->addButton('line', 'redline', 'view', 'crud::buttons.redline')->before('update');
+            $this->crud->addButton('line', 'redline', 'view', 'crud::buttons.redline')->makeFirst();
         });
 
         $this->crud->setupDefaultSaveActions();

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -39,12 +39,12 @@ class ProjectCrudController extends CrudController
 
     //use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
 
+    use ShowOperation;
     use ImportOperation;
-    use RedlineOperation;
     use AssessOperation;
+    use RedlineOperation;
     use FetchOperation;
     use UsesSaveAndNextAction;
-    use ShowOperation;
 
     /**
      * Configure the CrudPanel object. Apply settings to all operations.

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -6,6 +6,7 @@ use App\Models\RedLine;
 use App\Models\ScoreTag;
 use App\Models\CustomScoreTag;
 use App\Models\Principle;
+use Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
 use Illuminate\Support\Str;
 use App\Models\Organisation;
 use App\Imports\ProjectImport;
@@ -43,6 +44,7 @@ class ProjectCrudController extends CrudController
     use AssessOperation;
     use FetchOperation;
     use UsesSaveAndNextAction;
+    use ShowOperation;
 
     /**
      * Configure the CrudPanel object. Apply settings to all operations.
@@ -57,6 +59,8 @@ class ProjectCrudController extends CrudController
 
         CRUD::set('import.importer', ProjectImport::class);
         CRUD::set('import.template-path', 'AE Marker - Project Import Template.xlsx');
+
+        CRUD::setShowView('projects.show');
 
     }
 
@@ -381,6 +385,8 @@ class ProjectCrudController extends CrudController
             ]);
 
     }
+
+
 
 
     public function fetchScoreTag()

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -140,7 +140,7 @@ class Project extends Model
 
                 $total = $nonNaPrinciples->sum(fn($pr) => $pr->pivot->rating);
 
-                return $total / $totalPossible * 100;
+                return round($total / $totalPossible * 100, 1);
 
             }
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -24,14 +24,14 @@ class Project extends Model
 
     protected static function booted()
     {
-        static::creating(function($project) {
-            if (is_null($project->code)){
-                $org_project_number = Project::where('organisation_id', $project->organisation_id)->count()+1;
-                
+        static::creating(function ($project) {
+            if (is_null($project->code)) {
+                $org_project_number = Project::where('organisation_id', $project->organisation_id)->count() + 1;
+
                 $org_name = $project->organisation->name;
                 $org_name_words = explode(' ', $org_name);
                 $org_initials = "";
-                foreach($org_name_words as $word){
+                foreach ($org_name_words as $word) {
                     $org_initials = $org_initials . $word[0];
                 }
 
@@ -93,7 +93,7 @@ class Project extends Model
         return $this->hasMany(PrincipleProject::class);
     }
 
-    public function getOverallScoreAttribute()
+    public function getTotalPossibleAttribute()
     {
         if ($this->failingRedlines()->count() > 0) {
             return 0;
@@ -104,186 +104,246 @@ class Project extends Model
 
             $nonNaPrinciples = $principles->filter(fn($pr) => !$pr->pivot->is_na);
 
-            $totalPossible = $nonNaPrinciples->count() * 2;
+            return $nonNaPrinciples->count() * 2;
+        }
+    }
 
-            $total = $nonNaPrinciples->sum(fn($pr) => $pr->pivot->rating);
+        public function getTotalAttribute()
+        {
+            if ($this->failingRedlines()->count() > 0) {
+                return 0;
+            }
 
-            return $total / $totalPossible * 100;
+            if ($this->assessment_status === AssessmentStatus::Complete) {
+                $principles = $this->principles;
 
+                $nonNaPrinciples = $principles->filter(fn($pr) => !$pr->pivot->is_na);
+
+                return $nonNaPrinciples->sum(fn($pr) => $pr->pivot->rating);
+
+            }
         }
 
+        public
+        function getOverallScoreAttribute()
+        {
+            if ($this->failingRedlines()->count() > 0) {
+                return 0;
+            }
 
-        return null;
+            if ($this->assessment_status === AssessmentStatus::Complete) {
+                $principles = $this->principles;
+
+                $nonNaPrinciples = $principles->filter(fn($pr) => !$pr->pivot->is_na);
+
+                $totalPossible = $nonNaPrinciples->count() * 2;
+
+                $total = $nonNaPrinciples->sum(fn($pr) => $pr->pivot->rating);
+
+                return $total / $totalPossible * 100;
+
+            }
+
+
+            return null;
+        }
+
+        public
+        function organisation()
+        {
+            return $this->belongsTo(Organisation::class);
+        }
+
+        public
+        function customScoreTags()
+        {
+            return $this->hasMany(CustomScoreTag::class);
+        }
+
+        // Custom relationships to load scoreTags filtered by each of the 13 principles
+        // hard-coded principles, so careful if we change our definition of AE!
+        public
+        function scoreTags1()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 1);
+        }
+
+        public
+        function scoreTags2()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 2);
+        }
+
+        public
+        function scoreTags3()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 3);
+        }
+
+        public
+        function scoreTags4()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 4);
+        }
+
+        public
+        function scoreTags5()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 5);
+        }
+
+        public
+        function scoreTags6()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 6);
+        }
+
+        public
+        function scoreTags7()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 7);
+        }
+
+        public
+        function scoreTags8()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 8);
+        }
+
+        public
+        function scoreTags9()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 9);
+        }
+
+        public
+        function scoreTags10()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 10);
+        }
+
+        public
+        function scoreTags11()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 11);
+        }
+
+        public
+        function scoreTags12()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 12);
+        }
+
+        public
+        function scoreTags13()
+        {
+            return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
+                ->withPivot('principle_project_id')
+                ->where('principle_id', 13);
+        }
+
+        // Custom relationships to load customScoreTags filtered by each of the 13 principles
+        // hard-coded principles, so careful if we change our definition of AE!
+        public
+        function getCustomScoreTags1Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 1)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags2Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 2)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags3Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 3)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags4Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 4)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags5Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 5)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags6Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 6)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags7Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 7)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags8Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 8)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags9Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 9)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags10Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 10)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags11Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 11)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags12Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 12)->first()->customScoreTags->toArray();
+        }
+
+        public
+        function getCustomScoreTags13Attribute()
+        {
+            return $this->principleProjects()->where('principle_id', 13)->first()->customScoreTags->toArray();
+        }
+
     }
-
-    public function organisation()
-    {
-        return $this->belongsTo(Organisation::class);
-    }
-
-    public function customScoreTags()
-    {
-        return $this->hasMany(CustomScoreTag::class);
-    }
-
-    // Custom relationships to load scoreTags filtered by each of the 13 principles
-    // hard-coded principles, so careful if we change our definition of AE!
-    public function scoreTags1()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 1);
-    }
-
-    public function scoreTags2()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 2);
-    }
-
-    public function scoreTags3()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 3);
-    }
-
-    public function scoreTags4()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 4);
-    }
-
-    public function scoreTags5()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 5);
-    }
-
-    public function scoreTags6()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 6);
-    }
-
-    public function scoreTags7()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 7);
-    }
-
-    public function scoreTags8()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 8);
-    }
-
-    public function scoreTags9()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 9);
-    }
-
-    public function scoreTags10()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 10);
-    }
-
-    public function scoreTags11()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 11);
-    }
-
-    public function scoreTags12()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 12);
-    }
-
-    public function scoreTags13()
-    {
-        return $this->belongsToMany(ScoreTag::class, 'principle_project_score_tag', 'project_id', 'score_tag_id')
-            ->withPivot('principle_project_id')
-            ->where('principle_id', 13);
-    }
-
-    // Custom relationships to load customScoreTags filtered by each of the 13 principles
-    // hard-coded principles, so careful if we change our definition of AE!
-    public function getCustomScoreTags1Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 1)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags2Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 2)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags3Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 3)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags4Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 4)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags5Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 5)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags6Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 6)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags7Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 7)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags8Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 8)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags9Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 9)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags10Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 10)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags11Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 11)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags12Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 12)->first()->customScoreTags->toArray();
-    }
-
-    public function getCustomScoreTags13Attribute()
-    {
-        return $this->principleProjects()->where('principle_id', 13)->first()->customScoreTags->toArray();
-    }
-
-}

--- a/public/assets/js/admin/forms/project_assess.js
+++ b/public/assets/js/admin/forms/project_assess.js
@@ -145,7 +145,7 @@ document.querySelectorAll("[data-to-disable]")
             updateCount()
         })
 
-//set initial state
+        //set initial state
         if (el.checked) {
             let principleId = el.getAttribute('data-to-disable');
 

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -1,0 +1,183 @@
+@extends('backpack::layouts.top_left')
+
+@section('content')
+
+    <a href="{{backpack_url('project')}}" class="btn btn-link">Back to projects list</a>
+
+    <div class="container mt-4">
+
+        <h1>Project Review Page</h1>
+        <h2>{{ $entry->organisation->name }} - {{ $entry->name }}</h2>
+
+        <div class="row mt-3">
+            <div class="col-12 col-md-6 col-lg-6">
+
+                <table class="table table-borderless">
+                    <tr>
+                        <td class="text-right pr-4 mr-2">Project Code:</td>
+                        <td>{{ $entry->code }}</td>
+                    </tr>
+                    <tr>
+                        <td class="text-right pr-4 mr-2">Budget:</td>
+                        <td>USD {{ $entry->budget }}</td>
+                    </tr>
+                    <tr>
+                        <td class="text-right pr-4 mr-2">Status:</td>
+                        <td>{{ $entry->assessment_status }}</td>
+                    </tr>
+                    <tr>
+                        <td class="text-right pr-4 mr-2">Ratings Total:</td>
+                        @if($entry->assessment_status === \App\Enums\AssessmentStatus::Complete)
+                            <td>{{ $entry->total }} / {{ $entry->totalPossible }}</td>
+                        @else
+                            <td class="text-secondary">~~ Assessment not yet completed ~~</td>
+                        @endif
+                    </tr>
+                    <tr>
+                        <td class="text-right pr-4 mr-2">Overall Score:</td>
+                        @if($entry->assessment_status === \App\Enums\AssessmentStatus::Complete)
+                            <td><span class="font-weight-bold">{{ $entry->overall_score }} % </span>
+                                <br/>
+                                <span class="text-sm text-secondary">Calculated based on {{ $entry->principleProjects()->where('is_na', 0)->count() }} / 13 relevant principles.</span>
+                            </td>
+                        @else
+                            <td class="text-secondary">~~ Assessment not yet completed ~~</td>
+                        @endif
+                    </tr>
+                </table>
+            </div>
+
+            <div class="col-12">
+                <table class="table table-borderless table-responsive">
+                    <tr>
+                        <th>Principle</th>
+                        <th>Score</th>
+                        <th>Comments</th>
+                        <th>Shared Examples/Indicators</th>
+                        <th>Custom Examples/Indicators</th>
+                    </tr>
+
+                    @php
+                        $principleProjects = $entry->principleProjects;
+                    @endphp
+
+                    @foreach(\App\Models\Principle::all() as $principle)
+
+                        @php
+                            $principleProject = $principleProjects->where('principle_id', $principle->id)->first();
+                        @endphp
+                        <tr>
+                            <td>{{ $principle->name }}</td>
+                            <td> {{ $principleProject->is_na ? "NA" : $principleProject->rating }}</td>
+                            <td> {{ $principleProject->is_na ? "-" : $principleProject->rating_comment }}</td>
+                            <td>
+                                @if($principleProject->scoreTags()->count() > 0)
+                                    <button class="btn btn-link" type="button" data-toggle="modal"
+                                            data-target="#modal-shared-{{$principle->id}}">
+                                        {{ $principleProject->scoreTags()->count() }} selected
+                                    </button>
+                                @else
+                                    <span class="btn">0 selected</span>
+                                @endif
+                            </td>
+                            <td>
+                                @if($principleProject->customScoreTags()->count() > 0)
+                                    <button class="btn btn-link" type="button" data-toggle="modal"
+                                            data-target="#modal-custom-shared-{{$principle->id}}">
+                                        {{ $principleProject->customScoreTags()->count() }} added
+                                    </button>
+                                @else
+                                    <span class="btn">0 added</span>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+
+                </table>
+            </div>
+        </div>
+    </div>
+
+    @foreach(\App\Models\Principle::all() as $principle)
+
+        @php
+            $principleProjectModal = $principleProjects->where('principle_id', $principle->id)->first();
+        @endphp
+
+
+        {{-- Modal for Shared  Examples / Indicators--}}
+        <div class="modal fade" tabindex="-1" role="dialog" id="modal-shared-{{$principle->id}}">
+            <div class="modal-dialog modal-lg" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Examples / Indicators for {{ $principle->name }}</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="alert alert-info show">
+                            This is the list of examples / indicators that help explain the rating given
+                            for {{ $principle->name }}.
+                        </div>
+                        <table class="table table-borderless">
+                            <tr>
+                                <th>Example / Indicator</th>
+                            </tr>
+                            @foreach($principleProjectModal->scoreTags as $scoreTag)
+                                <tr>
+                                    <td>{{ $scoreTag->name }}</td>
+                                </tr>
+                            @endforeach
+                        </table>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Modal for CUSTOM  Examples / Indicators--}}
+        <div class="modal fade" tabindex="-1" role="dialog" id="modal-custom-shared-{{$principle->id}}">
+            <div class="modal-dialog modal-lg" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Examples / Indicators for {{ $principle->name }}</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="alert alert-info show">
+                            This is the list of custom examples / indicators added for this project to help explain the
+                            rating given for {{ $principle->name }}.
+                        </div>
+                        <table class="table  table-borderless">
+                            <tr>
+                                <th>Example / Indicator</th>
+                                <th>Description</th>
+                            </tr>
+                            @foreach($principleProjectModal->customScoreTags as $scoreTag)
+                                <tr>
+                                    <td>{{ $scoreTag->name }}</td>
+                                    <td>{{ $scoreTag->description }}</td>
+                                </tr>
+                            @endforeach
+                        </table>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endforeach
+
+@endsection
+
+@section('after_scripts')
+    <script src="{{ mix('js/app.js') }}"></script>
+@endsection


### PR DESCRIPTION
Add basic project review page:

- All projects now have a "preview" option from the main list page. 
- The preview shows the key project details at the top, and a table for the principle ratings, which shows:

- the score;
- comments;
- the count of shared examples / indicators;
- the count of custom examples / indicators;

Clicking on either count opens a modal that lists the selected (or added) scoreTags / customScoreTags. 


The Ratings Total and Overall score is only displayed if the projects status is "Assessment Complete"


