### PR TITLE
Tweaks

### DIFF
--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -260,6 +260,7 @@ class ProjectCrudController extends CrudController
             CRUD::field($principle->id . '_rating_comment')
                 ->tab($principle->name)
                 ->label('Comment for ' . $principle->name)
+                ->hint('Please add a comment, even if the principle is not applicable to this project.')
                 ->type('textarea')
                 ->default($principle->pivot->rating_comment);
 

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -37,8 +37,6 @@ class ProjectCrudController extends CrudController
     use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
 
-    //use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
-
     use ShowOperation;
     use ImportOperation;
     use AssessOperation;
@@ -62,6 +60,36 @@ class ProjectCrudController extends CrudController
 
         CRUD::setShowView('projects.show');
 
+    }
+
+    public function show($id)
+    {
+        $this->crud->hasAccessOrFail('show');
+
+        // get entry ID from Request (makes sure its the last ID for nested resources)
+        $id = $this->crud->getCurrentEntryId() ?? $id;
+
+        // get the info for that entry (include softDeleted items if the trait is used)
+        if ($this->crud->get('show.softDeletes') && in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->crud->model))) {
+            $this->data['entry'] = $this->crud->getModel()->withTrashed()->findOrFail($id);
+        } else {
+            $this->data['entry'] = $this->crud->getEntryWithLocale($id);
+        }
+
+        $this->data['crud'] = $this->crud;
+        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.preview').' '.$this->crud->entity_name;
+
+
+        // #### ADD SPIDER CHART DATA ###
+        $this->data['spiderData'] = $this->data['entry']->principleProjects->map(function($principleProject) {
+            return [
+                'axis' => $principleProject->principle->name,
+                'value' => $principleProject->rating,
+            ];
+        });
+
+        // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
+        return view($this->crud->getShowView(), $this->data);
     }
 
     /**

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -92,7 +92,11 @@ class ProjectCrudController extends CrudController
         CRUD::column('organisation')->type('relationship');
         CRUD::column('name');
         CRUD::column('code');
-        CRUD::column('budget')->type('number')->prefix('USD')->decimals(2)->thousands_sep(',');
+        CRUD::column('budget')->type('closure')->function(function($entry) {
+
+            $value = number_format($entry->budget, 2, '.', ',');
+            return "{$entry->currency} {$value}";
+        });
         CRUD::column('assessment_status')->type('closure')->function(function ($entry) {
             return $entry->assessment_status?->value;
         });
@@ -143,7 +147,14 @@ class ProjectCrudController extends CrudController
         CRUD::field('name');
         CRUD::field('code')->hint('The code should uniquely identify the project within your organisation\'s porfolio. Leave blank for an auto-generated code.');
         CRUD::field('description');
-        CRUD::field('budget')->prefix('USD');
+
+        CRUD::field('currency')
+            ->wrapper(['class' => 'form-group col-sm-3 required'])
+        ->attributes(['class' => 'form-control text-right'])
+            ->hint('Enter the 3-digit code for the currency, e.g. "EUR", or "USD"');
+        CRUD::field('budget')
+            ->wrapper(['class' => 'form-group col-sm-9 required'])
+        ->hint('Enter the overall budget for the project');
 
     }
 
@@ -315,7 +326,7 @@ class ProjectCrudController extends CrudController
     public function setupRedlineOperation()
     {
 
-        Widget::add()->type('script')->content('assets/js/admin/forms/redlines.js');
+        Widget::add()->type('script')->content('assets/js/admin/forms/project_redlines.js');
 
 
         CRUD::setHeading('');
@@ -349,7 +360,8 @@ class ProjectCrudController extends CrudController
                     'data-required' => '1',
                 ])
                 ->wrapper([
-                    'class' => 'col-md-6'
+                    'class' => 'col-md-6',
+                    'data-required-wrapper' => '1',
                 ])
                 ->options([
                     1 => 'Yes',
@@ -383,7 +395,6 @@ class ProjectCrudController extends CrudController
             ->attributes([
                 'disabled' => 'disabled',
             ]);
-
     }
 
 

--- a/app/Http/Controllers/Admin/UserCrudController.php
+++ b/app/Http/Controllers/Admin/UserCrudController.php
@@ -15,7 +15,7 @@ class UserCrudController extends CrudController
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation { update as traitUpdate; }
     use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
-    use ShowOperation;
+    //use ShowOperation;
 
     public function setup()
     {

--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -72,7 +72,8 @@ class OrganisationController extends Controller
             })->get();
 
         // comparative
-        $allRatings = Project::where('assessment_status', "=", AssessmentStatus::Complete)
+        $allRatings = Project::withoutGlobalScope('organisation')
+        ->where('assessment_status', "=", AssessmentStatus::Complete)
             ->with('principleProjects.principle')
             ->get()
             ->map(function ($project) {

--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -132,6 +132,8 @@ class OrganisationController extends Controller
 
         }
 
+        // TEMP HACK
+        $currency = $organisation->projects->first()->currency;
 
 
 
@@ -152,6 +154,7 @@ class OrganisationController extends Controller
             'allPortfolio' => $allPortfolio,
             'naPrinciples' => $naPrinciples,
             'passedProjects' => $passedProjects,
+            'currency' => $currency,
         ]);
     }
 

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -30,6 +30,7 @@ class ProjectRequest extends FormRequest
             'code' => ['nullable', 'string', new UniqueProjectCode],
             'description' => 'nullable|string',
             'budget' => 'required|integer',
+            'currency' => 'required|max:3',
         ];
     }
 

--- a/database/migrations/2022_11_24_093526_add_budget_to_projects_table.php
+++ b/database/migrations/2022_11_24_093526_add_budget_to_projects_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->string('currency', '3');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('currency');
+        });
+    }
+};

--- a/public/assets/js/admin/forms/project_assess.js
+++ b/public/assets/js/admin/forms/project_assess.js
@@ -1,7 +1,3 @@
-function validateScore(el) {
-
-}
-
 
 // when a principle rating is added; mark that tab as green / complete:
 

--- a/public/assets/js/admin/forms/project_assess.js
+++ b/public/assets/js/admin/forms/project_assess.js
@@ -173,9 +173,10 @@ function toggleFieldEnabled(principleId, shouldDisable) {
     console.log('principleId', principleId);
     console.log('should disable', shouldDisable);
 
-    if (shouldDisable) {
+    if (shouldDisable)
+    {
         crud.field(principleId + '_rating').disable();
-        crud.field(principleId + '_rating_comment').disable();
+        //crud.field(principleId + '_rating_comment').disable();
 
         crud.field('scoreTags' + principleId).disable();
         crud.field('customScoreTags' + principleId).disable();
@@ -185,7 +186,7 @@ function toggleFieldEnabled(principleId, shouldDisable) {
     } else {
 
         crud.field(principleId + '_rating').enable();
-        crud.field(principleId + '_rating_comment').enable();
+        //crud.field(principleId + '_rating_comment').enable();
         crud.field('scoreTags' + principleId).enable();
         crud.field('customScoreTags' + principleId).enable();
 

--- a/public/assets/js/admin/forms/project_assess.js
+++ b/public/assets/js/admin/forms/project_assess.js
@@ -1,4 +1,3 @@
-
 // when a principle rating is added; mark that tab as green / complete:
 
 function setTabAsComplete(tab) {
@@ -78,6 +77,11 @@ document.querySelectorAll("[data-update-tab='1']")
 
             if (!e.target.value) {
                 setRelatedTabToIncomplete(e.target);
+
+                e.target.classList.remove('is-invalid')
+                let validationMessage = document.getElementById("custom-validation-text-rating_" + e.target.getAttribute('data-tab'))
+                if (validationMessage) validationMessage.remove()
+
                 return;
             }
 
@@ -173,9 +177,14 @@ function toggleFieldEnabled(principleId, shouldDisable) {
     console.log('principleId', principleId);
     console.log('should disable', shouldDisable);
 
-    if (shouldDisable)
-    {
+    if (shouldDisable) {
+        crud.field(principleId + '_rating').input.value = '';
         crud.field(principleId + '_rating').disable();
+
+        crud.field(principleId + '_rating').input.classList.remove('is-invalid')
+        let validationMessage = document.getElementById("custom-validation-text-rating_" + crud.field(principleId + '_rating').input.getAttribute('data-tab'))
+        if (validationMessage) validationMessage.remove()
+
         //crud.field(principleId + '_rating_comment').disable();
 
         crud.field('scoreTags' + principleId).disable();

--- a/public/assets/js/admin/forms/project_create.js
+++ b/public/assets/js/admin/forms/project_create.js
@@ -1,0 +1,20 @@
+
+
+budgetField = document.getElementById('budget-field');
+
+console.log(budgetField);
+
+
+budgetField.addEventListener('onfocus', () => {
+  const value = node.value;
+  node.type = 'number';
+  console.log('number');
+  node.value = Number(value.replace(/,/g, '')); // or equivalent per locale
+});
+
+budgetField.addEventListener('onblur', () => {
+  const value = node.value;
+  node.type = 'text';
+  console.log('test');
+  node.value = value.toLocaleString();  // or other formatting
+});

--- a/public/assets/js/admin/forms/project_redlines.js
+++ b/public/assets/js/admin/forms/project_redlines.js
@@ -1,0 +1,37 @@
+var allRedlines = document.querySelectorAll("[data-required-wrapper='1']")
+
+console.log('hi', allRedlines.values())
+
+
+// do the initial check for completeness
+checkComplete()
+
+
+for (const radioField of allRedlines.values()) {
+
+
+    // on change, check all the others to see if they are completed.
+    radioField.addEventListener('change', e => {
+        checkComplete()
+    })
+
+    console.log('hi')
+    console.log(crud.field(radioField.getAttribute('bp-field-name')).value);
+}
+
+
+function checkComplete() {
+    let values = []
+    for (const innerField of allRedlines.values()) {
+        values.push(crud.field(innerField.getAttribute('bp-field-name')).value)
+    }
+
+    console.log(values);
+    if (values.includes('')) {
+        crud.field('redlines_complete').hide()
+        crud.field('redlines_incomplete').show()
+    } else {
+        crud.field('redlines_complete').show()
+        crud.field('redlines_incomplete').hide()
+    }
+}

--- a/resources/views/organisations/portfolio/_keyIndicators.blade.php
+++ b/resources/views/organisations/portfolio/_keyIndicators.blade.php
@@ -14,13 +14,13 @@
             </tr>
             <tr>
                 <th class="text-right mr-4">Total Budget for the period</th>
-                <td>{{  number_format($totalBudget)}} USD</td>
+                <td>{{ $currency }} {{  number_format($totalBudget)}}</td>
             </tr>
             <tr>
                 <th class="text-right mr-4">Agroecology Directed Budget<span
                             class="text-primary">*</span>
                 </th>
-                <td>{{ number_format($agroecologyBudget) }} USD</td>
+                <td>{{ $currency }} {{ number_format($agroecologyBudget) }}</td>
             </tr>
         </table>
         <span class="text-sm-left font-xs"><span class="text-primary">*</span> <span

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -9,8 +9,8 @@
         <h1>Project Review Page</h1>
         <h2>{{ $entry->organisation->name }} - {{ $entry->name }}</h2>
 
-        <div class="row mt-3">
-            <div class="col-12 col-md-6 col-lg-6">
+        <div class="row mt-3 mb-4">
+            <div class="col-12 col-md-6 col-lg-6 pt-4 mt-4 d-flex align-items-center">
 
                 <table class="table table-borderless">
                     <tr>
@@ -19,7 +19,7 @@
                     </tr>
                     <tr>
                         <td class="text-right pr-4 mr-2">Budget:</td>
-                        <td>USD {{ $entry->budget }}</td>
+                        <td>{{ $entry->currency }} {{ $entry->budget }}</td>
                     </tr>
                     <tr>
                         <td class="text-right pr-4 mr-2">Status:</td>
@@ -47,6 +47,11 @@
                 </table>
             </div>
 
+            <div class="col-12 col-md-6">
+                <div id="radarChart"></div>
+            </div>
+        </div>
+        <div class="row">
             <div class="col-12">
                 <table class="table table-borderless table-responsive">
                     <tr>
@@ -180,4 +185,44 @@
 
 @section('after_scripts')
     <script src="{{ mix('js/app.js') }}"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js" charset="utf-8"></script>
+
+    <script src="{{asset('js/radarChart.js')}}"></script>
+    <script>
+
+        /* Radar chart design created by Nadieh Bremer - VisualCinnamon.com */
+
+        //////////////////////////////////////////////////////////////
+        //////////////////////// Set-Up //////////////////////////////
+        //////////////////////////////////////////////////////////////
+
+        var margin = {top: 100, right: 100, bottom: 100, left: 100},
+            width = document.getElementById('radarChart').offsetWidth - margin.right - margin.left
+        height = Math.min(width, window.innerHeight - margin.top - margin.bottom - 20);
+
+        console.log('witdh', width);
+        //////////////////////////////////////////////////////////////
+        ////////////////////////// Data //////////////////////////////
+        //////////////////////////////////////////////////////////////
+
+        var data = [{!! $spiderData->values()->toJson() !!}];
+        //////////////////////////////////////////////////////////////
+        //////////////////// Draw the Chart //////////////////////////
+        //////////////////////////////////////////////////////////////
+
+        var color = d3.scale.ordinal()
+            .range(["#EDC951", "#CC333F", "#00A0B0"]);
+
+        var radarChartOptions = {
+            w: width,
+            h: height,
+            margin: margin,
+            maxValue: 2,
+            levels: 4,
+            roundStrokes: true,
+            color: color
+        };
+
+        window.spiderChart("#radarChart", data, radarChartOptions);
+    </script>
 @endsection


### PR DESCRIPTION
Many minor updates:

1. Portfolio dashboard now correctly compares 'your' organisation's projects vs *all* projects, instead of only retrieiving projects from organisations the user has access to.
2. Currency is now settable per-project. This causes issues when an org has projects in different currencies, as we would need to convert to show the totals. To be considered... 
3. fixed issue where  users can mark redlines as complete without selecting an option for all redlines. 
4. allow comments on principle-projects even when marked as n/a.
5. add spider chart to project show page.
6. remove show operation from users (as was unused and broken)
7. 