### PR TITLE
fixes for assessment process

### DIFF
--- a/app/Http/Controllers/AssessmentController.php
+++ b/app/Http/Controllers/AssessmentController.php
@@ -17,7 +17,7 @@ class AssessmentController extends Controller
     public function finaliseAssessment(Assessment $assessment)
     {
         if ($assessment->principleAssessments->every(fn($pa) => $pa->complete)) {
-            $assessment->assessment_status = AssessmentStatus::Complete;
+            $assessment->principle_status = AssessmentStatus::Complete;
             $assessment->save();
 
             Alert::success('The Principles Assessment for ' . $assessment->project->name . ' is now complete.')->flash();

--- a/resources/js/components/AgroecologicalPrinciplesAssessment.vue
+++ b/resources/js/components/AgroecologicalPrinciplesAssessment.vue
@@ -51,21 +51,23 @@
         </div>
         <p class="ml-auto mr-auto">Once you have completed all {{ principleAssessments.length }} principles, you may mark the assessment as complete below.</p>
     </div>
-    <div class="ml-auto mr-auto d-flex flex-column align-items-center">
+    <div class="ml-auto mr-auto d-flex flex-column align-items-center mt-4">
         <v-checkbox
             label="I confirm this assessment is complete and correct to the best of my knowledge."
             density="compact"
             hide-details="always"
             :disabled="!allComplete"
-            v-model="assessment.complete"
+            v-model="assessmentComplete"
         />
 
-        <form method="POST" :action="`/admin/assessment/${assessment.id}/finalise`">
+
+        <form method="POST" :action="`/admin/assessment/${assessment.id}/finalise`" class="mt-4" >
             <input type="hidden" name="_token" :value="csrf">
             <button
                 class="btn"
-                :class="assessment.complete ? 'btn-success' : 'btn-secondary'"
+                :class="assessmentComplete ? 'btn-success' : 'btn-secondary'"
                 type="submit"
+                :disabled="!assessmentComplete"
             >
                 Finalise Assessment
             </button>
@@ -82,7 +84,6 @@
             <PrincipleAssessmentModal
                 v-if="selectedPrincipleAssessment"
                 :principle-assessment="selectedPrincipleAssessment"
-                :is-open="modalIsOpen"
                 @discard="discard"
                 @close="modalIsOpen = false"
                 @next="next"
@@ -139,10 +140,8 @@ function next() {
     const index = principleAssessments.value.indexOf(selectedPrincipleAssessment.value)
 
     // if we've reached the end...
-    if (index >= selectedPrincipleAssessment.value.length) {
-        alert('complete')
+    if (index + 1 >= principleAssessments.value.length) {
         modalIsOpen.value = false
-
         return
     }
 
@@ -152,6 +151,8 @@ function next() {
 
 // handle completion
 const allComplete = computed(() => principleAssessments.value.every(pa => pa.complete))
+const assessmentComplete = ref(props.assessment.complete)
+
 
 function updateRating(principleAssessment) {
     const index = principleAssessments.value.findIndex(item => item.id === principleAssessment.id)

--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -126,12 +126,12 @@
 </template>
 
 <script setup>
-import {computed, ref, defineEmits, nextTick} from "vue";
+import {computed, ref, defineEmits, nextTick, onMounted} from "vue";
 
 
 const props = defineProps({
     principleAssessment: Object,
-    isOpen: Boolean,
+    closing: Boolean,
 })
 
 const principle = computed(() => props.principleAssessment.principle ?? null)
@@ -172,7 +172,6 @@ async function save(nextAction) {
 
     if (has_rating) {
         emit('update_rating', props.principleAssessment)
-
     }
 
     const res = await axios.patch(`/principle-assessment/${props.principleAssessment.id}`, props.principleAssessment)
@@ -180,6 +179,13 @@ async function save(nextAction) {
     emit(nextAction)
 
 }
+
+// slider appears to be '0' on null, but actually requrires moving up and back to 0 to be considered not null.
+onMounted(() => {
+    if(props.principleAssessment.rating === null) {
+        props.principleAssessment.rating = 0;
+    }
+})
 
 
 </script>


### PR DESCRIPTION
Fixes #80; Fixes #79;

- Fixes '0' vs null issue by automatically assigning the value 0 to the principleAssessment object when the modal is opened.
- Fixes the "finalise" checkbox by setting a new assessmentComplete variable (it was not properly updating the DOM when the props.assessment.complete was updating)
- Fixes reference to principle_status on finaliseAssessment POST request. 