### PR TITLE
add front-end to currency conversion for video demo

### DIFF
--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -177,7 +177,69 @@ class ProjectCrudController extends CrudController
             ->type('section-title')
             ->view_namespace('stats4sd.laravel-backpack-section-title::fields')
             ->title('Currency and Budget')
-            ->content("$selectedOrganisation->name uses $selectedOrganisation->currency as the default currency. You may change the currency for this initiative if you wish. For analysis, the budget will be converted into $selectedOrganisation->currency using the exchange rates from either the start date of the initiative (if in the past), or today (if the initiative has not yet started)");
+            ->content("$selectedOrganisation->name uses $selectedOrganisation->currency as the default currency. You may change the currency for this initiative if you wish. For analysis, the budget will be converted into $selectedOrganisation->currency.
+            <br/><br/>
+            The Platform can automatically convert the most common currencies using the exchange rate for the insitiative's start date (or today, if the initiative start is in the future).
+            <br/><br/>
+            For less commonly used currencies, or if you know the exchange rate to use, you can enter a custom exchange rate below.
+             <br/><br/>
+            <div class='btn btn-link' id='currencyListLabel' data-toggle='modal' data-target='#currencyList'><i class='la la-info-circle'></i> Which currencies can be automatically converted?</div>
+
+            <div class='modal fade' id='currencyList' tabindex=' - 1' aria-labelledby='currencyListLabel' aria-hidden='true'>
+              <div class='modal-dialog'>
+                <div class='modal-content'>
+                  <div class='modal-header'>
+                    <h5 class='modal-title' id='exampleModalLabel'>Currencies</h5>
+                    <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
+                      <span aria-hidden='true'>&times;</span>
+                    </button>
+                  </div>
+                  <div class='modal-body'>
+                    The platform currently has exchange rate information available for the following currencies:
+                    <ul>
+                        <li>EUR	Euro</li>
+                        <li>USD	(US Dollar)</li>
+                        <li>JPY	(Japanese Yen)</li>
+                        <li>BGN	(Bulgarian Lev)</li>
+                        <li>CZK	(Czech Republic Koruna)</li>
+                        <li>DKK	(Danish Krone)</li>
+                        <li>GBP	(British Pound Sterling)</li>
+                        <li>HUF	(Hungarian Forint)</li>
+                        <li>PLN	(Polish Zloty)</li>
+                        <li>RON	(Romanian Leu)</li>
+                        <li>SEK	(Swedish Krona)</li>
+                        <li>CHF	(Swiss Franc)</li>
+                        <li>ISK	(Icelandic Króna)</li>
+                        <li>NOK	(Norwegian Krone)</li>
+                        <li>HRK	(Croatian Kuna)</li>
+                        <li>RUB	(Russian Ruble)</li>
+                        <li>TRY	(Turkish Lira)</li>
+                        <li>AUD	(Australian Dollar)</li>
+                        <li>BRL	(Brazilian Real)</li>
+                        <li>CAD	(Canadian Dollar)</li>
+                        <li>CNY	(Chinese Yuan)</li>
+                        <li>HKD	(Hong Kong Dollar)</li>
+                        <li>IDR	(Indonesian Rupiah)</li>
+                        <li>ILS	(Israeli New Sheqel)</li>
+                        <li>INR	(Indian Rupee)</li>
+                        <li>KRW	(South Korean Won)</li>
+                        <li>MXN	(Mexican Peso)</li>
+                        <li>MYR	(Malaysian Ringgit)</li>
+                        <li>NZD	(New Zealand Dollar)</li>
+                        <li>PHP	(Philippine Peso)</li>
+                        <li>SGD	(Singapore Dollar)</li>
+                        <li>THB	(Thai Baht)</li>
+                        <li>ZAR	(South African Rand)</li>
+                    </ul>
+                  </div>
+                  <div class='modal-footer'>
+                    <button type='button' class='btn btn - secondary' data-dismiss='modal'>Close</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+ ");
 
         CRUD::field('currency')
             ->wrapper(['class' => 'form-group col-sm-3 required'])
@@ -186,6 +248,14 @@ class ProjectCrudController extends CrudController
         CRUD::field('budget')
             ->wrapper(['class' => 'form-group col-sm-9 required'])
             ->hint('Enter the overall budget for the project');
+
+
+        CRUD::field('exchange_rate')
+            ->label('Enter the exchange rate to be used:')
+            ->hint('1 of this initiative\'s currency = XXX ' . $selectedOrganisation->currency . '.')
+            ->type('number');
+
+
 
 
         CRUD::field('funding_sources_title')
@@ -330,15 +400,15 @@ class ProjectCrudController extends CrudController
 
         $this->data['title'] = 'Import ' . $this->crud->entity_name . ' from excel file';
 
-         $this->crud->addField([
+        $this->crud->addField([
             'name' => 'import-template',
             'type' => 'section-title',
             'view_namespace' => 'stats4sd.laravel-backpack-section-title::fields',
-            'title'  => 'Import Initiatives from Excel File',
+            'title' => 'Import Initiatives from Excel File',
             'content' => '
             Instead of manually entering details for individual initiatives, you may choose to import them in bulk, and then add additional details using the edit feature within the platform. To ensure a successful import, please download the template provided below, and ensure your Excel file is in the correct format. The template file includes an example initiative.
             <br/><br/>
-            <a href="' . url($this->crud->route.'/import-template') . '" class="btn btn-link" data-button-type="import-template"><i class="la la-download"></i> Download Template for Imports</a></br>
+            <a href="' . url($this->crud->route . '/import-template') . '" class="btn btn-link" data-button-type="import-template"><i class="la la-download"></i> Download Template for Imports</a></br>
 
             '
         ]);

--- a/database/migrations/2023_06_27_131129_add_custom_conversion_ratio_to_projects_table.php
+++ b/database/migrations/2023_06_27_131129_add_custom_conversion_ratio_to_projects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->decimal('exchange_rate', 10, 6)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
A small update - just the front-end section on the Initiatives creation page, so that the video guide can include the correct fields and information for adding the budget and currency to the initiatives. 