### PR TITLE
Change caption red line(s) to red flag(s)

### DIFF
--- a/app/Exports/Assessment/RedlinesExport.php
+++ b/app/Exports/Assessment/RedlinesExport.php
@@ -34,7 +34,7 @@ class RedlinesExport implements FromCollection, WithHeadings, WithTitle, WithStr
                     'initiative_name' => $project->name,
                     'red_flag' => $redline->name,
                     'present' => $redline->pivot->value,
-                    'redline_assessment_status' => $project->latest_assessment->redline_status,
+                    'red_flag_assessment_status' => $project->latest_assessment->redline_status,
                 ]);
             });
         });
@@ -52,12 +52,12 @@ class RedlinesExport implements FromCollection, WithHeadings, WithTitle, WithStr
             'initiative_name',
             'red_flag',
             'present',
-            'redline_assessment_status',
+            'red_flag_assessment_status',
         ];
     }
 
     public function title(): string
     {
-        return 'redflag_assessment';
+        return 'red_flag_assessment';
     }
 }

--- a/app/Http/Controllers/Admin/AssessmentCrudController.php
+++ b/app/Http/Controllers/Admin/AssessmentCrudController.php
@@ -226,11 +226,11 @@ class AssessmentCrudController extends CrudController
             ->type('section-title')
             ->view_namespace('stats4sd.laravel-backpack-section-title::fields')
             ->title(function ($entry) {
-                return "Assess Redlines for " . $entry->project->name;
+                return "Assess Red Flags for " . $entry->project->name;
             })
             ->content('
-                    Listed below is the set of red lines to check for each project.<br/><br/>
-                    These are the Red Line elements, which are counter-productive or harmful to the values and principles of agroecology. If any one of these is present in the project being rated, then the Agroecology Overall Score is 0.
+                    Listed below is the set of red flags to check for each project.<br/><br/>
+                    These are the Red Flag elements, which are counter-productive or harmful to the values and principles of agroecology. If any one of these is present in the project being rated, then the Agroecology Overall Score is 0.
                           ');
 
         // We cannot use the relationship with subfields field here, because we do not want the user to be able to unassign any redlines from the project.
@@ -268,20 +268,20 @@ class AssessmentCrudController extends CrudController
             ->type('section-title')
             ->view_namespace('stats4sd.laravel-backpack-section-title::fields')
             ->content('
-                Once you have completed the review of each redline, and are satisfied that the above entries are correct, please tick this box to confirm the review.<br/>
+                Once you have completed the review of each red flag, and are satisfied that the above entries are correct, please tick this box to confirm the review.<br/>
                 <i>(Note: You may still edit this review after marking it as complete)</i>
                 ');
 
 
         CRUD::field('redlines_complete')
             ->type('boolean')
-            ->label('I confirm the Redlines assessment is complete')
+            ->label('I confirm the Red Flags assessment is complete')
             ->default($entry->redline_status === AssessmentStatus::Complete->value);
 
         CRUD::field('redlines_incomplete')
             ->type('boolean')
-            ->label('I confirm the Redlines assessment is complete')
-            ->hint('You must assign a value (or mark as NA) for every redline above before marking the redline assessment as complete.')
+            ->label('I confirm the Red Flags assessment is complete')
+            ->hint('You must assign a value (or mark as NA) for every red flag above before marking the red flag assessment as complete.')
             ->attributes([
                 'disabled' => 'disabled',
             ]);

--- a/app/Http/Controllers/Admin/AssessmentCrudController.php
+++ b/app/Http/Controllers/Admin/AssessmentCrudController.php
@@ -268,7 +268,7 @@ class AssessmentCrudController extends CrudController
             ->type('section-title')
             ->view_namespace('stats4sd.laravel-backpack-section-title::fields')
             ->content('
-                Once you have completed the review of each red flag,  and are satisfied that the above entries are correct, please tick this box to confirm the review.<br/>
+                Once you have completed the review of each red flag, and are satisfied that the above entries are correct, please tick this box to confirm the review.<br/>
                 <i>(Note: You may still edit this review after marking it as complete)</i>
                 ');
 

--- a/app/Http/Controllers/Admin/AssessmentCrudController.php
+++ b/app/Http/Controllers/Admin/AssessmentCrudController.php
@@ -268,7 +268,7 @@ class AssessmentCrudController extends CrudController
             ->type('section-title')
             ->view_namespace('stats4sd.laravel-backpack-section-title::fields')
             ->content('
-                Once you have completed the review of each red flag, and are satisfied that the above entries are correct, please tick this box to confirm the review.<br/>
+                Once you have completed the review of each red flag,  and are satisfied that the above entries are correct, please tick this box to confirm the review.<br/>
                 <i>(Note: You may still edit this review after marking it as complete)</i>
                 ');
 

--- a/app/Http/Controllers/Admin/RedLineCrudController.php
+++ b/app/Http/Controllers/Admin/RedLineCrudController.php
@@ -31,8 +31,8 @@ class RedLineCrudController extends CrudController
     public function setup()
     {
         CRUD::setModel(\App\Models\RedLine::class);
-        CRUD::setRoute(config('backpack.base.route_prefix') . '/red-line');
-        CRUD::setEntityNameStrings('red line', 'red lines');
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/red-flag');
+        CRUD::setEntityNameStrings('red flag', 'red flags');
 
         CRUD::set('import.importer', RedLineImport::class);
     }

--- a/app/Models/Assessment.php
+++ b/app/Models/Assessment.php
@@ -31,7 +31,7 @@ class Assessment extends Model
     {
         // if redlines are not complete, use that status
         if($this->redline_status !== AssessmentStatus::Complete->value) {
-            return "Redlines " . $this->redline_status;
+            return "Red Flags " . $this->redline_status;
         }
 
         if($this->additionalCriteria->count() === 0 || $this->principle_status !== AssessmentStatus::Complete->value) {

--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -399,7 +399,7 @@ BEGIN
 
         -- construct status summary
         SET statusSummary = CONCAT('[',
-                                   '{\"status\":\"Passed all redlines\",\"number\":', ssPassedAllCount, ',\"percent\":', ssPassedAllPercent, ',\"budget\":\"', FORMAT(ssPassedAllBudget, 0), '\"},',
+                                   '{\"status\":\"Passed all red flags\",\"number\":', ssPassedAllCount, ',\"percent\":', ssPassedAllPercent, ',\"budget\":\"', FORMAT(ssPassedAllBudget, 0), '\"},',
                                    '{\"status\":\"Fully assessed\",\"number\":', ssFullyAssessedCount, ',\"percent\":', ssFullyAssessedPercent, ',\"budget\":\"', FORMAT(ssFullyAssessedBudget, 0), '\"}]');
 
         SET totalCount = ssCreatedCount;

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -54,7 +54,7 @@
                         <div class="col-12 col-lg-6">
                             <div class="d-flex justify-content-between mt-3 w-100">
                                 <div class="w-50">
-                                    <span class="font-weight-bold text-grey">REDLINES</span><br/>
+                                    <span class="font-weight-bold text-grey">RED FLAGS</span><br/>
                                     <span class="font-weight-bold">{{ initiative.latest_assessment.redline_status }}</span>
                                 </div>
                                 <div class="w-50">
@@ -63,7 +63,7 @@
                                         class="btn text-light w-100"
                                         :class="initiative.latest_assessment.redline_status === 'Complete' ? 'btn-info' : 'btn-success'"
                                     >
-                                        {{ initiative.latest_assessment.redline_status === 'Complete' ? 'Edit Redline Assessment' : 'Assess Redlines' }}
+                                        {{ initiative.latest_assessment.redline_status === 'Complete' ? 'Edit Red Flag Assessment' : 'Assess Red Flags' }}
                                     </a>
                                 </div>
                             </div>
@@ -80,7 +80,7 @@
                                         :class="initiative.latest_assessment.redline_status === 'Complete' ? (initiative.latest_assessment.principle_status === 'Complete' ? 'btn-info' : 'btn-success') : 'btn-info disabled'"
 
                                     >
-                                        {{ initiative.latest_assessment.principle_status === 'Complete' ? 'Edit Principle Assessment' : 'Assess Redlines' }}
+                                        {{ initiative.latest_assessment.principle_status === 'Complete' ? 'Edit Principle Assessment' : 'Assess Red Flags' }}
                                     </a>
                                 </div>
                             </div>
@@ -135,7 +135,7 @@ const nextAction = computed(() => {
 
     if (redlineStatus !== "Complete") {
         return {
-            label: "Assess Redlines",
+            label: "Assess Red Flags",
             url: `/admin/assessment/${props.initiative.latest_assessment.id}/redline`
         }
     }

--- a/resources/js/components/InitiativesList.vue
+++ b/resources/js/components/InitiativesList.vue
@@ -42,8 +42,8 @@
                     style="width: 250px"
                     class="mr-4 mb-3 mb-md-0"
                     v-model="redlineStatusFilter"
-                    :options="makeFilterOptions('Redlines')"
-                    placeholder="Filter By Redline Status"
+                    :options="makeFilterOptions('Red Flags')"
+                    placeholder="Filter By Red Flag Status"
                     :clearable="true"
                 />
 

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -261,7 +261,7 @@
                     <table class="table" v-if="summary.redlinesSummary != null">
 
                         <thead class="text-center">
-                        <th>Red Lines</th>
+                        <th>Red Flags</th>
                         <th>Yours</th>
                         <th>Others</th>
                         </thead>
@@ -281,7 +281,7 @@
                     <table class="table" v-if="summary.statusSummary != null">
                         <tbody class="text-center">
                         <tr v-for='summaryLine in summary.statusSummary'>
-                            <td v-if="summaryLine.status == 'Passed all redlines'" class="list-group-item d-flex font-lg text-deep-green">
+                            <td v-if="summaryLine.status == 'Passed all red flags'" class="list-group-item d-flex font-lg text-deep-green">
                                 <span class="w-50 text-right pr-4">{{ summaryLine.status }}</span>
                                 <span class="font-weight-bold ">{{ summaryLine.number }} ({{ summaryLine.percent }}%)</span>
                             </td>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -48,7 +48,7 @@ Route::group([
     Route::crud('organisation-crud', OrganisationCrudController::class);
 
 
-    Route::crud('red-line', RedLineCrudController::class);
+    Route::crud('red-flag', RedLineCrudController::class);
     Route::crud('principle', PrincipleCrudController::class);
     Route::crud('score-tag', ScoreTagCrudController::class);
 


### PR DESCRIPTION
This PR is submitted to solve issue #75.

Testing performed in local env with institutional admin and site admin respectively.

---

Changes made for below locations found for caption red line(s):

Initiatives > Filters
 - Filter by Redline Status
 - Redlines - Not Started
 - Redlines - In Progress
 - Redlines - Complete
 - Redlines - Failed

Initiatives > Export All Initiative Data
 - initiatives sheet > column R assessment_status > Redlines XXX
 - redflag_assessment sheet
 - redflag_assessment sheet > column I "redline_assessment_status"

Initiatives > Basic Info
 - Access Redlines

Initiatives > Show More Info
 - REDLINES
 - Edit Redline Assessment
 - Access Redlines

Dashboard > SUMMARY OF INITIATIVES
 - Passed all redlines

Dashboard > SUMMARY OF RED FLAGS
 - Red Lines
 - Passed all redlines