### PR TITLE
Add transition to principle assessment modals

### DIFF
--- a/resources/js/components/AgroecologicalPrinciplesAssessment.vue
+++ b/resources/js/components/AgroecologicalPrinciplesAssessment.vue
@@ -78,6 +78,7 @@
     <v-dialog
         v-model="modalIsOpen"
         width="80vw"
+        max-width="1500px"
         :scrollable="true"
     >
         <PrincipleAssessmentModal

--- a/resources/js/components/AgroecologicalPrinciplesAssessment.vue
+++ b/resources/js/components/AgroecologicalPrinciplesAssessment.vue
@@ -61,7 +61,7 @@
         />
 
 
-        <form method="POST" :action="`/admin/assessment/${assessment.id}/finalise`" class="mt-4" >
+        <form method="POST" :action="`/admin/assessment/${assessment.id}/finalise`" class="mt-4">
             <input type="hidden" name="_token" :value="csrf">
             <button
                 class="btn"
@@ -80,16 +80,14 @@
         width="80vw"
         :scrollable="true"
     >
-        <v-card>
-            <PrincipleAssessmentModal
-                v-if="selectedPrincipleAssessment"
-                :principle-assessment="selectedPrincipleAssessment"
-                @discard="discard"
-                @close="modalIsOpen = false"
-                @next="next"
-                @update_rating="updateRating"
-            />
-        </v-card>
+        <PrincipleAssessmentModal
+            v-if="selectedPrincipleAssessment"
+            :principle-assessment="selectedPrincipleAssessment"
+            @discard="discard"
+            @close="modalIsOpen = false"
+            @next="next"
+            @update_rating="updateRating"
+        />
 
     </v-dialog>
 </template>

--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -1,127 +1,131 @@
 <template>
 
+    <Transition mode="out-in" name="fade">
+        <v-card :key="principleAssessment">
+            <v-card-title class="px-0">
+                <h2 class="card-title text-bright-green pt-8 pb-0 px-12">{{ principle.name }}</h2>
+            </v-card-title>
 
-    <v-card-title class="px-0">
-        <h2 class="card-title text-bright-green pt-8 pb-0 px-12">{{ principle.name }}</h2>
-    </v-card-title>
+            <v-card-text class="px-0">
+                <div class="h-100 d-flex">
+                    <div class="col-md-6 px-12 py-4 h-100">
+                        <div>
+                            <h4>RATING</h4>
+                            <p class="pb-8 mb-4">Drag the slider to choose the rating for {{ principle.name }}. Refer to the definitions below if you are unsure.</p>
+                            <v-slider
+                                v-model="principleAssessment.rating"
+                                :min="0"
+                                :max="2"
+                                :step="0.1"
+                                :thumb-size="has_rating ? 18 : 24"
+                                :thumb-label="has_rating ? 'always' : 'never'"
+                                :thumb-color="has_rating ? 'green' : 'grey'"
+                                track-color="light"
+                                track-fill-color="success"
+                                show-ticks="always"
+                                class="ae-slider"
+                                :disabled="principleAssessment.is_na"
+                            >
+                                <template #thumb-label="data">
+                                    {{ has_rating ? principleAssessment.rating : '' }}
+                                </template>
+                                <template #tick-label="data">
+                                    {{ data.tick.value % 1 === 0 ? data.tick.value : '' }}
+                                </template>
+                            </v-slider>
 
-    <v-card-text class="px-0">
-        <div class="h-100 d-flex">
-            <div class="col-md-6 px-12 py-4 h-100">
-                <div>
-                    <h4>RATING</h4>
-                    <p class="pb-8 mb-4">Drag the slider to choose the rating for {{ principle.name }}. Refer to the definitions below if you are unsure.</p>
-                    <v-slider
-                        v-model="principleAssessment.rating"
-                        :min="0"
-                        :max="2"
-                        :step="0.1"
-                        :thumb-size="has_rating ? 18 : 24"
-                        :thumb-label="has_rating ? 'always' : 'never'"
-                        :thumb-color="has_rating ? 'green' : 'grey'"
-                        track-color="light"
-                        track-fill-color="success"
-                        show-ticks="always"
-                        class="ae-slider"
-                        :disabled="principleAssessment.is_na"
-                    >
-                        <template #thumb-label="data">
-                            {{ has_rating ? principleAssessment.rating : '' }}
-                        </template>
-                        <template #tick-label="data">
-                            {{ data.tick.value % 1 === 0 ? data.tick.value : '' }}
-                        </template>
-                    </v-slider>
+                            <v-checkbox
+                                class="my-4"
+                                v-model="principleAssessment.is_na"
+                                :label="`If ${principle.name.toLowerCase()} is not applicable for this project, tick this box.`">
+                            </v-checkbox>
+                            <p class="alert alert-info" v-if="principleAssessment.is_na">You may still add a comment to explain why {{ principle.name }} is not applicable for this project.</p>
+                        </div>
 
-                    <v-checkbox
-                        class="my-4"
-                        v-model="principleAssessment.is_na"
-                        :label="`If ${principle.name.toLowerCase()} is not applicable for this project, tick this box.`">
-                    </v-checkbox>
-                    <p class="alert alert-info" v-if="principleAssessment.is_na">You may still add a comment to explain why {{ principle.name }} is not applicable for this project.</p>
-                </div>
+                        <div class="card bg-bright-green text-white rounded-b-xl rounded-t-xl mb-16">
+                            <div class="card-body p-4 px-8">
+                                <h3 class="card-title">Definitions</h3>
 
-                <div class="card bg-bright-green text-white rounded-b-xl rounded-t-xl mb-16">
-                    <div class="card-body p-4 px-8">
-                        <h3 class="card-title">Definitions</h3>
+                                <table class="align-text-top">
+                                    <tr>
+                                        <td class="align-text-top pr-4 pb-4">2</td>
+                                        <td class="align-text-top pr-4 pb-4">{{ principle.rating_two }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="align-text-top pr-4 pb-4">1</td>
+                                        <td class="align-text-top pr-4 pb-4">{{ principle.rating_one }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="align-text-top pr-4 pb-4">0</td>
+                                        <td class="align-text-top pr-4 pb-4">{{ principle.rating_zero }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="align-text-top pr-4 pb-4">N/A</td>
+                                        <td class="align-text-top pr-4 pb-4">{{ principle.rating_na }}</td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </div>
 
-                        <table class="align-text-top">
-                            <tr>
-                                <td class="align-text-top pr-4 pb-4">2</td>
-                                <td class="align-text-top pr-4 pb-4">{{ principle.rating_two }}</td>
-                            </tr>
-                            <tr>
-                                <td class="align-text-top pr-4 pb-4">1</td>
-                                <td class="align-text-top pr-4 pb-4">{{ principle.rating_one }}</td>
-                            </tr>
-                            <tr>
-                                <td class="align-text-top pr-4 pb-4">0</td>
-                                <td class="align-text-top pr-4 pb-4">{{ principle.rating_zero }}</td>
-                            </tr>
-                            <tr>
-                                <td class="align-text-top pr-4 pb-4">N/A</td>
-                                <td class="align-text-top pr-4 pb-4">{{ principle.rating_na }}</td>
-                            </tr>
-                        </table>
+
                     </div>
+
+                    <div class="col-md-6 px-12 py-4 h-100">
+                        <h4 class="mb-4">COMMENTS AND EXAMPLES</h4>
+
+                        <div>
+                            <v-textarea
+                                v-model="principleAssessment.rating_comment"
+                                label="Add a comment to support your rating"
+                            ></v-textarea>
+                        </div>
+
+                        <div>
+                            <h6>Presence of Examples // Indicators for {{ principle.name }}</h6>
+                            <p>Below are some common examples of {{ principle.name }} within a project. Tick the ones that are present within the project. You may also add additional examples below to further support the rating given.</p>
+
+                            <div v-for="tag in principle.score_tags" class="checkbox-group mb-2 example-list">
+                                <v-checkbox
+                                    v-model="principleAssessment.score_tag_ids"
+                                    :value="tag.id"
+                                    :label="tag.name"
+                                    density="compact"
+                                    hide-details="auto"
+                                ></v-checkbox>
+                            </div>
+                        </div>
+
+                        <div class="mt-8">
+                            <div v-for="(tag, index) in principleAssessment.custom_score_tags" class="d-flex form-group">
+
+                                <v-text-field
+                                    ref="tagNameRefs"
+                                    v-model="tag.name"
+                                    label="Enter a descriptive name for the example / indicator"
+                                    density="compact"
+                                    variant="underlined"
+                                    append-icon="mdi-delete"
+                                    @click:append="removeCustomScoreTag(index)"
+                                />
+                            </div>
+
+                            <button class="btn btn-secondary" @click="addCustomScoreTag">
+                                <i class="la la-plus"></i> Add New Example
+                            </button>
+                        </div>
+
+                    </div>
+
                 </div>
-
-
+            </v-card-text>
+            <div class="card-footer d-flex justify-content-between" style="margin-left: 25%; margin-right: 25%">
+                <div class="btn btn-secondary" @click="discard">Discard Changes</div>
+                <div class="btn btn-primary" @click="save('close')">Save and Close</div>
+                <div class="btn btn-success" @click="save('next')">Save and Next</div>
             </div>
 
-            <div class="col-md-6 px-12 py-4 h-100">
-                <h4 class="mb-4">COMMENTS AND EXAMPLES</h4>
-
-                <div>
-                    <v-textarea
-                        v-model="principleAssessment.rating_comment"
-                        label="Add a comment to support your rating"
-                    ></v-textarea>
-                </div>
-
-                <div>
-                    <h6>Presence of Examples / Indicators for {{ principle.name }}</h6>
-                    <p>Below are some common examples of {{ principle.name }} within a project. Tick the ones that are present within the project. You may also add additional examples below to further support the rating given.</p>
-
-                    <div v-for="tag in principle.score_tags" class="checkbox-group mb-2 example-list">
-                        <v-checkbox
-                            v-model="principleAssessment.score_tag_ids"
-                            :value="tag.id"
-                            :label="tag.name"
-                            density="compact"
-                            hide-details="auto"
-                        ></v-checkbox>
-                    </div>
-                </div>
-
-                <div class="mt-8">
-                    <div v-for="(tag, index) in principleAssessment.custom_score_tags" class="d-flex form-group">
-
-                        <v-text-field
-                            ref="tagNameRefs"
-                            v-model="tag.name"
-                            label="Enter a descriptive name for the example / indicator"
-                            density="compact"
-                            variant="underlined"
-                            append-icon="mdi-delete"
-                            @click:append="removeCustomScoreTag(index)"
-                        />
-                    </div>
-
-                    <button class="btn btn-secondary" @click="addCustomScoreTag">
-                        <i class="la la-plus"></i> Add New Example
-                    </button>
-                </div>
-
-            </div>
-
-        </div>
-    </v-card-text>
-    <div class="card-footer d-flex justify-content-between" style="margin-left: 25%; margin-right: 25%">
-        <div class="btn btn-secondary" @click="discard">Discard Changes</div>
-        <div class="btn btn-primary" @click="save('close')">Save and Close</div>
-        <div class="btn btn-success" @click="save('next')">Save and Next</div>
-    </div>
+        </v-card>
+    </Transition>
 
 </template>
 
@@ -182,7 +186,7 @@ async function save(nextAction) {
 
 // slider appears to be '0' on null, but actually requrires moving up and back to 0 to be considered not null.
 onMounted(() => {
-    if(props.principleAssessment.rating === null) {
+    if (props.principleAssessment.rating === null) {
         props.principleAssessment.rating = 0;
     }
 })
@@ -206,6 +210,16 @@ onMounted(() => {
     background-color: #fff;
     width: 100%;
     max-width: 1200px;
+}
+
+
+.fade-enter-active, .fade-leave-active {
+    transition: opacity .2s ease;
+}
+
+.fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */
+{
+    opacity: 0;
 }
 
 </style>


### PR DESCRIPTION
Minor PR - adds a subtle transition to the PrincipleAssessmentModal component. Previously, when you clicked "save and next" during the principle assessment it was not immediately obvious that the content had changed. This adds a small fade-out and in to make it easier to see that you have moved to the next principle in the list. 

Also added a max-width for styling on wider screens. 


