### PR TITLE
Fix initiative sorting

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -24,9 +24,10 @@ class ProjectController extends Controller
                 'additionalCriteria',
             ],
         ])
+            // by default, initaitives are sorted by name in ascending order
+            ->orderBy('name', 'asc')
             ->get()
             ->map(fn(Project $project) => $project->append('latest_assessment'));
-
 
         $org = Organisation::find(Session::get('selectedOrganisationId'));
 

--- a/resources/js/components/InitiativesList.vue
+++ b/resources/js/components/InitiativesList.vue
@@ -222,11 +222,12 @@ function resetFilters() {
     principleStatusFilter.value = '';
     portfolioFilter.value = '';
     searchString.value = '';
+
+    handlePortfolioFromUrl();
 }
 
 // handle portfolio from url
-onMounted(() => {
-
+function handlePortfolioFromUrl() {
     const querypairs = window.location.search.substring(1);
     const test = new URLSearchParams(querypairs)
     console.log(test)
@@ -236,7 +237,11 @@ onMounted(() => {
             portfolioFilter.value = value;
         }
     })
+}
 
+
+onMounted(() => {
+    handlePortfolioFromUrl();
 })
 
 

--- a/resources/js/components/InitiativesList.vue
+++ b/resources/js/components/InitiativesList.vue
@@ -113,6 +113,7 @@ const sortOptions = ref([
     }
 ])
 
+// default value for sortBy and sortDir, which is sorted by name in ascending order
 const sortBy = ref('name')
 const sortDir = ref(1)
 
@@ -123,8 +124,8 @@ const propComparator = (propName, sortDir) =>
 watch(sortDir, (newSortDir) => {
     props.initiatives.sort(propComparator(sortBy.value, newSortDir))
 })
+
 watch(sortBy, (newSortBy) => {
-    console.log('hi');
     props.initiatives.sort(propComparator(newSortBy, sortDir.value))
 })
 
@@ -133,6 +134,9 @@ watch(sortBy, (newSortBy) => {
 const redlineStatusFilter = ref('');
 const principleStatusFilter = ref('');
 const portfolioFilter = ref('');
+
+// keyword search filter
+const searchString = ref('')
 
 const portfolios = computed(() => {
     return props.initiatives.map(initiative => initiative.portfolio.name)
@@ -174,38 +178,50 @@ function makeFilterOptions(string) {
 }
 
 const filteredInitiatives = computed(() => {
-    return props.initiatives.filter(initiative => {
-        if (redlineStatusFilter.value) {
-            return initiative.latest_assessment.redline_status === redlineStatusFilter.value.value
-        }
+    // just mentioning variables, computed() function will be triggered when their value changed
+    sortBy.value;
+    sortDir.value;
 
-        return true;
-    })
-        .filter(initiative => {
-            if (principleStatusFilter.value) {
-                return initiative.latest_assessment.principle_status === principleStatusFilter.value.value
-            }
+    // declare temporary variables for filtering
+    let tempInitiatives;
+    tempInitiatives = props.initiatives;
 
-            return true;
-        })
-        .filter(initiative => {
-            if (portfolioFilter.value) {
-                return initiative.portfolio.name === portfolioFilter.value
-            }
+    // apply filter for red flag status
+    if (redlineStatusFilter.value) {
+        tempInitiatives = tempInitiatives.filter(
+            initiative => initiative.latest_assessment.redline_status === redlineStatusFilter.value.value
+        )
+    }
 
-            return true;
-        })
-        .filter(initiative => {
+    // apply filter for principle status
+    if (principleStatusFilter.value) {
+        tempInitiatives = tempInitiatives.filter(
+            initiative => initiative.latest_assessment.principle_status === principleStatusFilter.value.value
+        )
+    }
 
-            if (searchString.value !== '') {
-                return initiative.name.toLowerCase().includes(searchString.value.toLowerCase())
-            }
+    // apply filter for portfolio
+    if (portfolioFilter.value) {
+        tempInitiatives = tempInitiatives.filter(
+            initiative => initiative.portfolio.name === portfolioFilter.value
+        )
+    }
 
-            return true
-        })
+    // apply filter for keyword
+    if (searchString.value !== '') {
+        tempInitiatives = tempInitiatives.filter(
+            initiative => initiative.name.toLowerCase().includes(searchString.value.toLowerCase())
+        )
+    }
+
+    return tempInitiatives;
 })
 
 function resetFilters() {
+    redlineStatusFilter.value = '';
+    principleStatusFilter.value = '';
+    portfolioFilter.value = '';
+    searchString.value = '';
 }
 
 // handle portfolio from url
@@ -222,9 +238,6 @@ onMounted(() => {
     })
 
 })
-
-//  search
-const searchString = ref('')
 
 
 </script>


### PR DESCRIPTION
This PR is submitted for fix issue #93.

It contains below changes:
1. Revise codes for filtering records, make sorting works when no filter applied
2. Add sortBy, sortDir in computed() function, make sorting works when any filter applied
3. Complete resetFilters() function, make Reset button works
4. Sort initiatives records by name in ascending order, which match the default value of sortBy and sortDir
5. Special handling for Reset button when there is a portfolio specified in GET parameter