### PR TITLE
Dashboard get summary when change portfolio

### DIFF
--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -427,20 +427,29 @@ const summary = ref({
 })
 
 async function getData() {
-
     let data = {...filters.value}
 
     data.organisation_id = props.organisation.id
 
     const res = await axios.post("/admin/generic-dashboard/enquire", data)
     summary.value = res.data
-
-
 }
 
 function formatBudget(amount) {
     return amount ? amount.toLocaleString() : '';
 }
+
+watch(filters.value, (newValue, oldValue) => {
+    if (newValue.portfolio == null) {
+        // after clicking "Reset" button
+        console.log("watch() triggered, no need to call getData()");
+    } else {
+        // when user select a portfolio, get summary data for the selected portfolio
+        console.log("watch() triggered, call getData()");
+        getData();
+    }
+})
+
 
 
 // **************** ChartJS ****************

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -442,10 +442,10 @@ function formatBudget(amount) {
 watch(filters.value, (newValue, oldValue) => {
     if (newValue.portfolio == null) {
         // after clicking "Reset" button
-        console.log("watch() triggered, no need to call getData()");
+        // console.log("watch() triggered, no need to call getData()");
     } else {
         // when user select a portfolio, get summary data for the selected portfolio
-        console.log("watch() triggered, call getData()");
+        // console.log("watch() triggered, call getData()");
         getData();
     }
 })


### PR DESCRIPTION
This PR is submitted to fix issue #95.

This is considered as an enhancement for more intuative UI/UX.

---

Screen shots:

Enter dashboard, summary data showed for all portfolios
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/2aa02c85-b8d6-46ed-ac35-77174c5f2a9b)

Select a portfolio, summary data showed for selected portfolio
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/911f45c3-7a1b-4f28-b062-bce1874e633b)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/c2ac31f2-ba9a-45e2-8fa0-adda6b8cf621)

Select another portfolio, summary data showed for another selected portfolio
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/2b8bcb17-a388-4de6-b7a9-a5258e2567f6)

Reset Filters, summary data showed for all portfolios
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/0ead8d65-5e97-4d78-ba1f-ae01e75907cf)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/b401215a-dc02-476a-a0a1-2ba64f83ac89)
