### PR TITLE
Dashboard error handling

### DIFF
--- a/app/Http/Controllers/GenericDashboardController.php
+++ b/app/Http/Controllers/GenericDashboardController.php
@@ -261,13 +261,29 @@ class GenericDashboardController extends Controller
             ->where('dashboard_id', $dashboardYoursId))
             ->get();
 
-        $assessmentScore = $allAssessments->sum(fn(Assessment $assessment) => $assessment->overall_score)
-            / $allAssessments->where('completed_at', '!=', null)->count();
+        $noOfInitiativeCompletedAssessment = $allAssessments->where('completed_at', '!=', null)->count();
 
+        // initialise variables
+        $assessmentScore = 'N/A';
+        $aeBudget = 'N/A';
 
-        $aeBudget = round($results[0]->totalBudget * ($assessmentScore / 100), 0);
+        // error handling to avoid division by zero error
+        if ($noOfInitiativeCompletedAssessment == 0) {
 
-        $assessmentScore = round($assessmentScore, 1);
+            $status = 2001;
+            $message = 'There is no fully assessed initiative';
+
+        } else {
+
+            // calculate overall score and AE budget if number of fully assess initiative is bigger than zero
+            $assessmentScore = $allAssessments->sum(fn(Assessment $assessment) => $assessment->overall_score)
+                / $noOfInitiativeCompletedAssessment;
+
+            $aeBudget = round($results[0]->totalBudget * ($assessmentScore / 100), 0);
+
+            $assessmentScore = round($assessmentScore, 1);
+
+        }
 
         // construct JSON response
         $jsonRes = [];

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -80,7 +80,7 @@
                                         :class="initiative.latest_assessment.redline_status === 'Complete' ? (initiative.latest_assessment.principle_status === 'Complete' ? 'btn-info' : 'btn-success') : 'btn-info disabled'"
 
                                     >
-                                        {{ initiative.latest_assessment.principle_status === 'Complete' ? 'Edit Principle Assessment' : 'Assess Red Flags' }}
+                                        {{ initiative.latest_assessment.principle_status === 'Complete' ? 'Edit Principle Assessment' : 'Assess Principles' }}
                                     </a>
                                 </div>
                             </div>

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -153,6 +153,10 @@
         </div>
     </div>
 
+    <div v-if="summary.status != 0" class="alert alert-warning text-dark">
+        {{ summary.message }}
+    </div>
+
     <div v-if="summary.tooFewOtherProjects" class="alert alert-warning text-dark">
         NOTE: The chosen filters have resulted in a comparison dataset too small to guarantee anonymity, so the "other instutitions" results will not be shown.
     </div>


### PR DESCRIPTION
This PR is submitted to fix issue #98 and #99.

It contains below changes:
1. Dashboard, show error message returned from database stored procedure
2. Dashboard, show error message if there is no fully assessed initiative, Overall score and AE budget are showed as "N/A"
3. Fix a minor typo in InitiativeListCard.vue: "Assess Principles" button instead of "Assess Red Flags" button.

Screen shot:

BEFORE
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/208145c3-ef34-4f54-a7df-a032496ba907)

AFTER
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/cb844bcb-2647-4c17-860a-8c8252dcd132)

