### PR TITLE
Dashboard, sort principles by principle number 

### DIFF
--- a/app/Http/Controllers/GenericDashboardController.php
+++ b/app/Http/Controllers/GenericDashboardController.php
@@ -96,7 +96,8 @@ class GenericDashboardController extends Controller
         $budgetFrom = $request['minBudget'] ?? 'null';
         $budgetTo = $request['maxBudget'] ?? 'null';
 
-        $sortBy = $request['sortBy'] ?? '1';
+        // sort principles by principle number by default
+        $sortBy = $request['sortBy'] ?? '3';
 
         // constrcuct dynamic SQL
         $sql = "CALL generate_dashboard_summary(


### PR DESCRIPTION
This PR is submitted to fix issue #118.

According to user discussion in demonstration meeting on 2023-06-26, users suggested to sort principles by principle numbers in dashboard.

This will ease user to compare principles of different portfolios.

---

Screen shots:

BEFORE:

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/119117c5-40f3-43a3-9d3d-ff8567c6b6a0)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/6c831379-4e89-4bd3-93a7-76abeb682bba)

AFTER:

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/19082078-746c-40e6-bac2-e114a06da116)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/986ba3d9-3868-42c4-bc5c-08b935f0a37a)
