### PR TITLE
Enhance Dashboard

### DIFF
--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -420,7 +420,7 @@ BEGIN
 
         IF rsRedLineCount = 0 THEN
             SET status = 1002;
-            SET message = 'There is no red line reviewed';
+            SET message = 'There is no red flag reviewed';
 
             DELETE FROM dashboard_result WHERE dashboard_id = dashboardYoursId;
 

--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -500,6 +500,11 @@ BEGIN
             -- PRINCIPLES SUMMARY
             -- -------------------------
 
+            -- in table dashboard_assessment, remove latest assessment records if assessment.redline_status is not Complete
+            CALL remove_incomplete_dashboard_assessment(dashboardYoursId);
+            CALL remove_incomplete_dashboard_assessment(dashboardOthersId);
+
+
             SELECT COUNT(*)
             INTO psPrincipleCount
             FROM principle_assessment

--- a/database/procedures/remove_incomplete_dashboard_assessment.sql
+++ b/database/procedures/remove_incomplete_dashboard_assessment.sql
@@ -1,0 +1,52 @@
+DROP PROCEDURE IF EXISTS `remove_incomplete_dashboard_assessment`;
+
+CREATE PROCEDURE `remove_incomplete_dashboard_assessment`(
+	dashboardId INT
+)
+BEGIN
+
+	-- variables for latest assessment
+	DECLARE psAssessmentId INT;
+
+	-- variable to determine whether it is end of cursor
+	DECLARE psDone INT DEFAULT FALSE;
+
+	-- cursor to find latest assessment with non "Complete" redline_status in table dashboard_assessment
+	DECLARE psCursor CURSOR FOR
+	SELECT tb.id
+	FROM dashboard_assessment ta, assessments tb
+	WHERE ta.assessment_id = tb.id
+	AND ta.dashboard_id = dashboardId
+	AND tb.redline_status != 'Complete';
+
+	-- handler declaration
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET psDone = TRUE;
+
+
+	-- open cursor
+	OPEN psCursor;
+
+	-- loop
+	ps_read_loop: LOOP
+
+		-- fetch one record from cursor
+		FETCH psCursor INTO psAssessmentId;
+
+		DELETE FROM dashboard_assessment
+		WHERE dashboard_id = dashboardId
+		AND assessment_id = psAssessmentId;
+
+		-- exit loop if it is end of cursor
+		IF psDone THEN
+		  	LEAVE ps_read_loop;
+		END IF;
+
+	-- end loop
+	END LOOP ps_read_loop;
+
+	-- close cursor
+	CLOSE psCursor;
+
+	COMMIT;
+
+END


### PR DESCRIPTION
In principle summary, all principles assessed in latest assessments are included even assessment.redline_status is not Complete.

This is not common, but it could happen for below scenario:
After principle assessment, user can assess red flag and change any red flag to YES to have 0 score.

This PR is submitted to exclude any latest assessments if it's redline_status is not Complete.

---

Screen shots:

A portfolio has two initiative. The first initiative has failed red flags assessment.

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/f9a9b1a7-df96-44b2-a186-47365f67b6be)

BEFORE:
Last assessments of both two initiatives are included in principle summary.
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/390f0231-fa7e-41ca-a8bc-86fc723397b7)

AFTER:
The first failed initiative is excluded from principle summary. Only the second Complete assessment is included in principle summary.
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/bbaaaf2f-37a6-45ff-a20e-0728a70f4037)
