### PR TITLE
Set defaults for org table

### DIFF
--- a/database/migrations/2023_07_12_140706_set_default_has_additional_criteria_to_zero_for_organisations_table.php
+++ b/database/migrations/2023_07_12_140706_set_default_has_additional_criteria_to_zero_for_organisations_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->boolean('has_additional_criteria')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->boolean('has_additional_criteria')->change();
+        });
+    }
+};


### PR DESCRIPTION
When reviewing PRs today, I noticed that the seeders were failing when creating organisations. It looks like there was no default set for `has_additional_criteria`, and the seeders were written before we added that. 

This tiny PR fixes this, so now `php artisan migrate:fresh --seed` runs smoothly again for testing purposes. 