### PR TITLE
Show is_na checkbox if principle is can_be_na

### DIFF
--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -34,7 +34,7 @@
                                 </template>
                             </v-slider>
 
-                            <v-checkbox
+                            <v-checkbox v-if="principle.can_be_na==1"
                                 class="my-4"
                                 v-model="principleAssessment.is_na"
                                 :label="`If ${principle.name.toLowerCase()} is not applicable for this project, tick this box.`">


### PR DESCRIPTION
This PR is submitted for fix issue #121.

Now the is_na checkbox will not be showed if principle.can_be_na is 0.

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/59c5d304-1833-46d8-bf79-f5b7ecd10392)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/83f4f64e-b357-4a25-8374-7e504be3005b)
