### PR TITLE
browsershot-test: url instead of html

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,7 @@ DATA_REMOVAL_ALERT_RECIPIENTS=admin@example.com
 
 # Free currency API key
 CURRENCY_API_KEY=CURRENCY_API_KEY
+
+# Browsershot local auth
+ADMIN_EMAIL=site_admin@example.com
+ADMIN_PASSWORD=password

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -72,18 +72,21 @@ class ProjectCrudController extends CrudController
 
     public function show($id)
     {
-        $this->authorize('view', Project::find($id));
+        //$this->authorize('view', Project::find($id));
 
-        $this->crud->hasAccessOrFail('show');
+        //$this->crud->hasAccessOrFail('show');
 
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
 
         // get the info for that entry (include softDeleted items if the trait is used)
         if ($this->crud->get('show.softDeletes') && in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->crud->model))) {
-            $this->data['entry'] = $this->crud->getModel()->withTrashed()->findOrFail($id);
+            $this->data['entry'] = $this->crud->getModel()
+                ->withoutGlobalScopes('organisation')
+                ->withTrashed()
+                ->findOrFail($id);
         } else {
-            $this->data['entry'] = $this->crud->getEntryWithLocale($id);
+            $this->data['entry'] = Project::withoutGlobalScopes(['organisation'])->find($id);
         }
 
         $this->data = self::getShowData($this->data);

--- a/app/Http/Controllers/GeneratePdfFileController.php
+++ b/app/Http/Controllers/GeneratePdfFileController.php
@@ -13,21 +13,22 @@ use Spatie\Browsershot\Browsershot;
 class GeneratePdfFileController extends Controller
 {
 
-    public function generatePdfFile(Request $request, string $name = null)
+    public function generatePdfFile(string $url, string $name = null)
     {
         // get the URL that sent PDF generation request
-        $url = $request->header('referer');
+
 
         // visit URL with logged in session, get HTML body content
-        $opts = ['http' => ['header' => 'Cookie: ' . $_SERVER['HTTP_COOKIE'] . "\r\n"]];
-        $context = stream_context_create($opts);
-        $htmlContent = file_get_contents($url, false, $context);
+        //$opts = ['http' => ['header' => 'Cookie: ' . $_SERVER['HTTP_COOKIE'] . "\r\n"]];
+        //$context = stream_context_create($opts);
+        //$htmlContent = file_get_contents($url, false, $context);
 
         $path = $name ?? Auth::id() . '__' . Carbon::now()->timestamp;
 
         // pass HTML body content to Browsershot, output as PDF
-        Browsershot::html($htmlContent)
-//            ->landscape()
+        Browsershot::url($url)
+                ->authenticate(config('services.browsershot.auth.email'), config('services.browsershot.auth.password'))
+ //           ->landscape()
 //            ->margins(0, 0, 0, 0)
 //            ->waitUntilNetworkIdle()
             ->save(Storage::path("prints/$path.pdf"));
@@ -41,7 +42,7 @@ class GeneratePdfFileController extends Controller
     {
         $filename = $project->name . '-summary-' . Carbon::now()->toDateString();
 
-        return $this->generatePdfFile(request(), $filename);
+        return $this->generatePdfFile(route('project.show-as-pdf', ['id' => $project->id]), $filename);
     }
 
     public function download(string $filename)

--- a/config/services.php
+++ b/config/services.php
@@ -23,4 +23,11 @@ return [
     'currency' => [
         'api-key' => env('CURRENCY_API_KEY'),
     ],
+
+    'browsershot' => [
+        'auth' => [
+            'email' => env('ADMIN_EMAIL'),
+            'password' => env('ADMIN_PASSWORD'),
+        ],
+    ],
 ];

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -134,4 +134,10 @@ Route::group([
     });
 
 
-}); // this should be the absolute last line of this file
+});
+
+// for use with Browsershot:
+
+Route::get('project/{id}/show-as-pdf', [ProjectCrudController::class, 'show'])
+    ->middleware('auth.basic')
+    ->name('project.show-as-pdf');


### PR DESCRIPTION
Browsershot was previously not running the JavaScript correctly to produce the chart in the pdf. 

A post from back in 2020 suggested that this is an issue with using `Browsershot::html()`, but it works with `Browsershot::url()`. 

So this PR moves to using `url()`, and adds the needed infrastructure to allow the headless Chrome instance to authenticate via http basic auth. Unfortuantely this means that we can't use the user's own account to authenticate, but given they need to be authenticated to even trigger the browsershot method, I think this is ok. 

I've added a TODO item to double check the security of the initiative show info page after these changes. 