### PR TITLE
Additional score tags

### DIFF
--- a/app/Http/Controllers/AdditionalAssessmentController.php
+++ b/app/Http/Controllers/AdditionalAssessmentController.php
@@ -17,7 +17,7 @@ class AdditionalAssessmentController extends Controller
     {
         $query = AdditionalCriteriaAssessment::with(
             'assessment',
-            'principle',
+            'principle.scoreTags',
             'additionalCriteria.scoreTags',
             'scoreTags',
             'customScoreTags'

--- a/app/Http/Controllers/AdditionalAssessmentController.php
+++ b/app/Http/Controllers/AdditionalAssessmentController.php
@@ -18,7 +18,6 @@ class AdditionalAssessmentController extends Controller
         $query = AdditionalCriteriaAssessment::with(
             'assessment',
             'principle.scoreTags',
-            'additionalCriteria.scoreTags',
             'scoreTags',
             'customScoreTags'
         );


### PR DESCRIPTION
fixes #141.

Fixes the relationship call in the query to get the AdditionalCriteriaAssessment data for the Additional Criteria Assessment front-end. 

The Vue component uses "principle" as the name of the relationship (to harmonise with PrincipleAssessment). So to display the linked scoreTags we need to use `principle.scoreTag` not `additionalAssessment.scoreTag`. 