### PR TITLE
add 'next assessment stage' buttons to red flags and principles

### DIFF
--- a/app/Http/Controllers/Admin/AssessmentCrudController.php
+++ b/app/Http/Controllers/Admin/AssessmentCrudController.php
@@ -274,8 +274,10 @@ class AssessmentCrudController extends CrudController
 
         CRUD::field('redlines_complete')
             ->type('boolean')
-            ->label('I confirm the Red Flags assessment is complete')
-            ->default($entry->redline_status === AssessmentStatus::Complete->value);
+            ->label('I confirm the Red Flags assessment is complete.')
+            ->default(
+                in_array($entry->redline_status,
+                    [AssessmentStatus::Complete->value, AssessmentStatus::Failed->value], false));
 
         CRUD::field('redlines_incomplete')
             ->type('boolean')
@@ -285,7 +287,8 @@ class AssessmentCrudController extends CrudController
                 'disabled' => 'disabled',
             ]);
 
-        $this->removeAllSaveActions();
-        $this->addSaveAndReturnToProjectListAction();
+        // save actions now hardcoded for redline operation
+//        $this->removeAllSaveActions();
+//        $this->addSaveAndReturnToProjectListAction();
     }
 }

--- a/app/Http/Controllers/Admin/Operations/RedlineOperation.php
+++ b/app/Http/Controllers/Admin/Operations/RedlineOperation.php
@@ -127,7 +127,6 @@ trait RedlineOperation
 
         $latestAssessment->save();
 
-        dd($request->all());
         // use redirect from request to determine redirect
         return redirect(backpack_url($request->input('redirect') ?? 'project'));
     }

--- a/app/Http/Controllers/Admin/Operations/RedlineOperation.php
+++ b/app/Http/Controllers/Admin/Operations/RedlineOperation.php
@@ -78,6 +78,7 @@ trait RedlineOperation
 
     public function postRedlineForm(Request $request)
     {
+
         if ($request->has('redlines_compelete') && $request->redlines_complete === 1) {
             foreach (RedLine::all() as $redline) {
                 if ($request->has('redline_value_' . $redline->id)) {
@@ -126,7 +127,16 @@ trait RedlineOperation
 
         $latestAssessment->save();
 
+        // use save action to determine redirect
 
-        return redirect(backpack_url('project'));
+
+        if($request->input('_save_action') === 'assessment') {
+            $redirect = backpack_url("assessment/$latestAssessment->id/assess");
+        } else {
+            $redirect = backpack_url('project');
+        }
+
+
+        return redirect($redirect);
     }
 }

--- a/app/Http/Controllers/Admin/Operations/RedlineOperation.php
+++ b/app/Http/Controllers/Admin/Operations/RedlineOperation.php
@@ -127,16 +127,8 @@ trait RedlineOperation
 
         $latestAssessment->save();
 
-        // use save action to determine redirect
-
-
-        if($request->input('_save_action') === 'assessment') {
-            $redirect = backpack_url("assessment/$latestAssessment->id/assess");
-        } else {
-            $redirect = backpack_url('project');
-        }
-
-
-        return redirect($redirect);
+        dd($request->all());
+        // use redirect from request to determine redirect
+        return redirect(backpack_url($request->input('redirect') ?? 'project'));
     }
 }

--- a/app/Http/Controllers/Admin/Operations/RedlineOperation.php
+++ b/app/Http/Controllers/Admin/Operations/RedlineOperation.php
@@ -128,6 +128,6 @@ trait RedlineOperation
         $latestAssessment->save();
 
         // use redirect from request to determine redirect
-        return redirect(backpack_url($request->input('redirect') ?? 'project'));
+        return redirect(backpack_url($request->input('_redirect') ?? 'project'));
     }
 }

--- a/app/Http/Controllers/Admin/Traits/UsesSaveAndNextAction.php
+++ b/app/Http/Controllers/Admin/Traits/UsesSaveAndNextAction.php
@@ -65,20 +65,23 @@ trait UsesSaveAndNextAction
 
     public function addSaveAndReturnToProjectListAction(): void
     {
-
-        // These buttons are only used for the redirect action after save. The other properties are hard-coded into the redline.blade.php view.
         $this->crud->addSaveAction([
             'name' => 'save_and_return_to_projects',
             'redirect' => function ($crud, $request, $itemId){
                 return backpack_url('project');
-            },
-        ]);
+            }, // what's the redirect URL, where the user will be taken after saving?
 
-        $this->crud->addSaveAction([
-            'name' => 'save_and_start_assessment',
-            'redirect' => function($crud, $request, $itemId) {
-                return backpack_url("assessment/$itemId/assess");
-            },
+            // OPTIONAL:
+            'button_text' => 'Save and Return', // override text appearing on the button
+            // You can also provide translatable texts, for example:
+            // 'button_text' => trans('backpack::crud.save_action_one'),
+            'visible' => function ($crud) {
+                return true;
+            }, // customize when this save action is visible for the current operation
+            'referrer_url' => function ($crud, $request, $itemId) {
+                return $crud->route;
+            }, // override http_referrer_url
+            'order' => 1, // change the order save actions are in
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/Traits/UsesSaveAndNextAction.php
+++ b/app/Http/Controllers/Admin/Traits/UsesSaveAndNextAction.php
@@ -65,23 +65,20 @@ trait UsesSaveAndNextAction
 
     public function addSaveAndReturnToProjectListAction(): void
     {
+
+        // These buttons are only used for the redirect action after save. The other properties are hard-coded into the redline.blade.php view.
         $this->crud->addSaveAction([
             'name' => 'save_and_return_to_projects',
             'redirect' => function ($crud, $request, $itemId){
                 return backpack_url('project');
-            }, // what's the redirect URL, where the user will be taken after saving?
+            },
+        ]);
 
-            // OPTIONAL:
-            'button_text' => 'Save and Return', // override text appearing on the button
-            // You can also provide translatable texts, for example:
-            // 'button_text' => trans('backpack::crud.save_action_one'),
-            'visible' => function ($crud) {
-                return true;
-            }, // customize when this save action is visible for the current operation
-            'referrer_url' => function ($crud, $request, $itemId) {
-                return $crud->route;
-            }, // override http_referrer_url
-            'order' => 1, // change the order save actions are in
+        $this->crud->addSaveAction([
+            'name' => 'save_and_start_assessment',
+            'redirect' => function($crud, $request, $itemId) {
+                return backpack_url("assessment/$itemId/assess");
+            },
         ]);
     }
 }

--- a/app/Http/Controllers/AssessmentController.php
+++ b/app/Http/Controllers/AssessmentController.php
@@ -11,6 +11,8 @@ class AssessmentController extends Controller
 
     public function assess(Assessment $assessment)
     {
+        $assessment->has_additional_criteria = $assessment->project->organisation->has_additional_criteria;
+
         return view("crud::operations.assess", ['assessment' => $assessment]);
     }
 
@@ -26,10 +28,12 @@ class AssessmentController extends Controller
             $assessment->save();
 
             Alert::success('The Principles Assessment for ' . $assessment->project->name . ' is now complete.')->flash();
-            return redirect('/admin/project');
+
+            return redirect(request()->input('_redirect') ?? '/admin/project');
         }
 
         Alert::warning('It looks like the assessment is not yet complete. Please check you have given a rating to all applicable principles.')->flash();
+
         return back();
 
     }

--- a/public/assets/js/admin/forms/project_redlines.js
+++ b/public/assets/js/admin/forms/project_redlines.js
@@ -32,7 +32,7 @@ function checkComplete() {
         const passed = checkPassed(values)
         const nextButton = document.getElementById('start-principle-assessment-button')
 
-        if(passed) {
+        if (passed) {
 
             nextButton.classList.add('active')
             nextButton.classList.add('btn-success')
@@ -50,30 +50,30 @@ function checkComplete() {
 function checkPassed(values) {
 
     // also return false if the user has not confirmed the assessment as complete
-    if(crud.field('redlines_complete').value !== '1') {
+    if (crud.field('redlines_complete').value !== '1') {
         return false;
     }
 
-    if(values.includes('1')) {
+    if (values.includes('1')) {
         return false;
     }
 
     return true;
 }
 
-        function startAssessment(button, redirect) {
+function startAssessment(button, redirect) {
 
-            // if the form is not complete / the button is not active, do nothing
-            if (!button.classList.contains('active')) {
-                return;
-            }
+    // if the form is not complete / the button is not active, do nothing
+    if (!button.classList.contains('active')) {
+        return;
+    }
 
-            var form = document.getElementById('redlines-form')
-            var redirectElement = document.getElementById('_redirect')
+    var form = document.getElementById('redlines-form')
+    var redirectElement = document.getElementById('_redirect')
 
-            redirectElement.value = redirect
+    redirectElement.value = redirect
 
-            form.requestSubmit()
+    form.requestSubmit()
 
 
-        }
+}

--- a/public/assets/js/admin/forms/project_redlines.js
+++ b/public/assets/js/admin/forms/project_redlines.js
@@ -5,14 +5,14 @@ checkComplete()
 
 
 for (const radioField of allRedlines.values()) {
-
-
     // on change, check all the others to see if they are completed.
     radioField.addEventListener('change', e => {
         checkComplete()
     })
-
 }
+
+// check for completeness + passed when the complete checkbox is updated.
+crud.field('redlines_complete').onChange((field) => checkComplete())
 
 
 function checkComplete() {
@@ -21,7 +21,6 @@ function checkComplete() {
         values.push(crud.field(innerField.getAttribute('bp-field-name')).value)
     }
 
-    console.log(values);
     if (values.includes('')) {
         crud.field('redlines_complete').hide()
         crud.field('redlines_incomplete').show()
@@ -49,6 +48,12 @@ function checkComplete() {
 }
 
 function checkPassed(values) {
+
+    // also return false if the user has not confirmed the assessment as complete
+    if(crud.field('redlines_complete').value !== '1') {
+        return false;
+    }
+
     if(values.includes('1')) {
         return false;
     }

--- a/public/assets/js/admin/forms/project_redlines.js
+++ b/public/assets/js/admin/forms/project_redlines.js
@@ -60,3 +60,20 @@ function checkPassed(values) {
 
     return true;
 }
+
+        function startAssessment(button, redirect) {
+
+            // if the form is not complete / the button is not active, do nothing
+            if (!button.classList.contains('active')) {
+                return;
+            }
+
+            var form = document.getElementById('redlines-form')
+            var redirectElement = document.getElementById('_redirect')
+
+            redirectElement.value = redirect
+
+            form.requestSubmit()
+
+
+        }

--- a/public/assets/js/admin/forms/project_redlines.js
+++ b/public/assets/js/admin/forms/project_redlines.js
@@ -1,8 +1,5 @@
 var allRedlines = document.querySelectorAll("[data-required-wrapper='1']")
 
-console.log('hi', allRedlines.values())
-
-
 // do the initial check for completeness
 checkComplete()
 
@@ -15,8 +12,6 @@ for (const radioField of allRedlines.values()) {
         checkComplete()
     })
 
-    console.log('hi')
-    console.log(crud.field(radioField.getAttribute('bp-field-name')).value);
 }
 
 
@@ -33,5 +28,30 @@ function checkComplete() {
     } else {
         crud.field('redlines_complete').show()
         crud.field('redlines_incomplete').hide()
+
+        // enable or disable principle assessment link
+        const passed = checkPassed(values)
+        const nextButton = document.getElementById('start-principle-assessment-button')
+
+        if(passed) {
+
+            nextButton.classList.add('active')
+            nextButton.classList.add('btn-success')
+            nextButton.classList.remove('btn-secondary')
+
+
+        } else {
+            nextButton.classList.remove('active')
+            nextButton.classList.add('btn-secondary')
+            nextButton.classList.remove('btn-success')
+        }
     }
+}
+
+function checkPassed(values) {
+    if(values.includes('1')) {
+        return false;
+    }
+
+    return true;
 }

--- a/public/assets/js/admin/forms/redlines.js
+++ b/public/assets/js/admin/forms/redlines.js
@@ -12,6 +12,8 @@ function updateCount() {
     if(countRequired === countFinished) {
         crud.field('redlines_complete').show();
         crud.field('redlines_incomplete').hide();
+
+
     } else {
         crud.field('redlines_complete').hide();
         crud.field('redlines_incomplete').show();
@@ -28,4 +30,3 @@ document.querySelectorAll("[data-required='1']")
     })
 
 updateCount()
-

--- a/resources/js/components/AgroecologicalPrinciplesAssessment.vue
+++ b/resources/js/components/AgroecologicalPrinciplesAssessment.vue
@@ -6,15 +6,22 @@
                 <div class="mb-5">
 
 
-                    This is the main section of the review. Below are the 13 Agroecology Principles, and you should rate the project against each one.
+                    This is the main section of the review. Below are the 13 Agroecology Principles, and you should rate
+                    the project against each one.
                     <br/><br/>
                     For each principle, you should give:
 
                     <ul>
-                        <li>A rating: This is a number between 0 and 2, based on your appreciation of the value of the principle in the project design / activities, and following the Spectrum defined for each principle. Decimal digits are allowed.</li>
-                        <li>A comment: Please add any comments to help explain the rating, and about how the principle is seen within the project.</li>
+                        <li>A rating: This is a number between 0 and 2, based on your appreciation of the value of the
+                            principle in the project design / activities, and following the Spectrum defined for each
+                            principle. Decimal digits are allowed.
+                        </li>
+                        <li>A comment: Please add any comments to help explain the rating, and about how the principle
+                            is seen within the project.
+                        </li>
                     </ul>
-                    Each principle also lists a set of example activities relevant to that principle. Please tick all activities that are present in the project.
+                    Each principle also lists a set of example activities relevant to that principle. Please tick all
+                    activities that are present in the project.
                     <br/><br/>
                     <b class="text-deep-green">Click on a principle to begin:</b>
                 </div>
@@ -34,8 +41,11 @@
                                 >
                                     <span>{{ principleAssessment.principle.name }}</span>
                                     <div class="d-flex align-items-end">
-                                        <h5 class="py-0 m-0 pr-4" style="line-height: 1.3em;" v-if="principleAssessment.complete">
-                                            {{ principleAssessment.is_na ? 'N/A' : Math.round(principleAssessment.rating * 10) / 10 }}
+                                        <h5 class="py-0 m-0 pr-4" style="line-height: 1.3em;"
+                                            v-if="principleAssessment.complete">
+                                            {{
+                                                principleAssessment.is_na ? 'N/A' : Math.round(principleAssessment.rating * 10) / 10
+                                            }}
                                         </h5>
                                         <h3 class="p-0 m-0 d-flex">
                                             <i :class="principleAssessment.complete ? 'la la-check-circle' : 'la la-edit'"></i>
@@ -49,7 +59,8 @@
 
             </div>
         </div>
-        <p class="ml-auto mr-auto">Once you have completed all {{ principleAssessments.length }} principles, you may mark the assessment as complete below.</p>
+        <p class="ml-auto mr-auto">Once you have completed all {{ principleAssessments.length }} principles, you may
+            mark the assessment as complete below.</p>
     </div>
     <div class="ml-auto mr-auto d-flex flex-column align-items-center mt-4">
         <v-checkbox
@@ -60,18 +71,35 @@
             v-model="assessmentComplete"
         />
 
+        <div class="d-flex justify-content-around">
 
-        <form method="POST" :action="`/admin/${assessmentType}/${assessment.id}/finalise`" class="mt-4">
-            <input type="hidden" name="_token" :value="csrf">
-            <button
-                class="btn"
-                :class="assessmentComplete ? 'btn-success' : 'btn-secondary'"
-                type="submit"
-                :disabled="!assessmentComplete"
-            >
-                Finalise Assessment
-            </button>
-        </form>
+            <form method="POST" :action="`/admin/${assessmentType}/${assessment.id}/finalise`" class="mt-4">
+                <input type="hidden" name="_token" :value="csrf">
+                <input type="hidden" name="_redirect" value="/admin/project">
+                <button
+                    class="btn"
+                    :class="assessmentComplete ? 'btn-success' : 'btn-secondary'"
+                    type="submit"
+                    :disabled="!assessmentComplete"
+                >
+                    <span class="la la-save"></span> Finalise Assessment
+                </button>
+            </form>
+
+            <form method="POST" :action="`/admin/${assessmentType}/${assessment.id}/finalise`" class="mt-4 ml-4"
+                  v-if="assessment.has_additional_criteria">
+                <input type="hidden" name="_token" :value="csrf">
+                <input type="hidden" name="_redirect" :value="`/admin/assessment/${assessment.id}/assess-custom`">
+                <button
+                    class="btn"
+                    :class="assessmentComplete ? 'btn-success' : 'btn-secondary'"
+                    type="submit"
+                    :disabled="!assessmentComplete"
+                >
+                    <span class="la la-arrow-right"></span>  Finalise and begin Additional Assessment
+                </button>
+            </form>
+        </div>
     </div>
 
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -274,3 +274,7 @@ label {
 .example-list label {
     margin-left: 10px;
 }
+
+.btn.active {
+    cursor: pointer;
+}

--- a/resources/views/vendor/backpack/crud/operations/redline.blade.php
+++ b/resources/views/vendor/backpack/crud/operations/redline.blade.php
@@ -73,7 +73,7 @@
 
                 <div class="form-group" id="saveActions">
 
-                    <input type="hidden" id="_save_action" name="_save_action">
+                    <input type="hidden" id="_redirect" name="_redirect" value="project">
 
 
                     <a href="{{ url($crud->route) }}" class="btn btn-default">
@@ -81,13 +81,13 @@
                         <span>Cancel</span>
                     </a>
 
-                    <button type="submit" class="btn btn-primary" data-value="save_and_return_to_projects">
-                        <span class="la la-save" role="presentation" aria-hidden="true" onclick="startAssessment('project')"></span>
+                    <button type="submit" class="btn btn-primary" data-value="save_and_return_to_projects" onclick="startAssessment('project')">
+                        <span class="la la-save" role="presentation" aria-hidden="true"></span>
                         <span>Save and Return</span>
                     </button>
 
                     <div id="start-principle-assessment-button" class="btn btn-secondary active"
-                         data-value="save_and_start_assessment" onclick="startAssessment('assessment')" disabled>
+                         data-value="save_and_start_assessment" onclick="startAssessment('{{"assessment/".$entry->getKey()."/assess"}}')" disabled>
                         <span class="la la-arrow-right" role="presentation" aria-hidden="true"></span>
                         <span>Save and Start Principle Assessment</span>
                     </div>
@@ -122,10 +122,11 @@
         }
 
         function startAssessment(redirect) {
-            var form = document.getElementById('redlines-form')
-            var saveElement = document.getElementById('_save_action')
 
-            saveElement.value = redirect
+            var form = document.getElementById('redlines-form')
+            var redirectElement = document.getElementById('_redirect')
+
+            redirectElement.value = redirect
 
             form.requestSubmit()
 

--- a/resources/views/vendor/backpack/crud/operations/redline.blade.php
+++ b/resources/views/vendor/backpack/crud/operations/redline.blade.php
@@ -1,71 +1,136 @@
 @extends(backpack_view('blank'))
 
 @php
-  $defaultBreadcrumbs = [
-    trans('backpack::crud.admin') => backpack_url('dashboard'),
-    $crud->entity_name_plural => url($crud->route),
-    trans('backpack::crud.assess') => false,
-  ];
+    $defaultBreadcrumbs = [
+      trans('backpack::crud.admin') => backpack_url('dashboard'),
+      $crud->entity_name_plural => url($crud->route),
+      trans('backpack::crud.assess') => false,
+    ];
 
-  // if breadcrumbs aren't defined in the CrudController, use the default breadcrumbs
-  $breadcrumbs = $breadcrumbs ?? $defaultBreadcrumbs;
+    // if breadcrumbs aren't defined in the CrudController, use the default breadcrumbs
+    $breadcrumbs = $breadcrumbs ?? $defaultBreadcrumbs;
 @endphp
 
 @section('header')
-	<section class="container-fluid">
-	  <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+    <section class="container-fluid">
+        <h2>
+            <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
 
-        @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-        @endif
-	  </h2>
-	</section>
+            @if ($crud->hasAccess('list'))
+                <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i
+                            class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }}
+                        <span>{{ $crud->entity_name_plural }}</span></a></small>
+            @endif
+        </h2>
+    </section>
 @endsection
 
 @section('content')
-<div class="row">
-	<div class="{{ $crud->getEditContentClass() }}">
-		{{-- Default box --}}
+    <div class="row">
+        <div class="{{ $crud->getEditContentClass() }}">
+            {{-- Default box --}}
 
-		@include('crud::inc.grouped_errors')
+            @include('crud::inc.grouped_errors')
 
-		  <form method="post"
-		  		action="{{ url($crud->route.'/'.$entry->getKey()).'/redline' }}"
-				@if ($crud->hasUploadFields('update', $entry->getKey()))
-				enctype="multipart/form-data"
-				@endif
-		  		>
-		  {!! csrf_field() !!}
-		  {!! method_field('PUT') !!}
+            <form
+                id="redlines-form"
+                method="post"
+                  action="{{ url($crud->route.'/'.$entry->getKey()).'/redline' }}"
+                  @if ($crud->hasUploadFields('update', $entry->getKey()))
+                      enctype="multipart/form-data"
+                @endif
+            >
+                {!! csrf_field() !!}
+                {!! method_field('PUT') !!}
 
-		  	@if ($crud->model->translationEnabled())
-		    <div class="mb-2 text-right">
-		    	{{-- Single button --}}
-				<div class="btn-group">
-				  <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[request()->input('_locale')?request()->input('_locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
-				  </button>
-				  <ul class="dropdown-menu">
-				  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)
-					  	<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/redline') }}?_locale={{ $key }}">{{ $locale }}</a>
-				  	@endforeach
-				  </ul>
-				</div>
-		    </div>
-		    @endif
-		      {{-- load the view from the application if it exists, otherwise load the one in the package --}}
-		      @if(view()->exists('vendor.backpack.crud.form_content'))
-		      	@include('vendor.backpack.crud.form_content', ['fields' => $crud->fields(), 'action' => 'redline'])
-		      @else
-		      	@include('crud::form_content', ['fields' => $crud->fields(), 'action' => 'redline'])
-              @endif
-              {{-- This makes sure that all field assets are loaded. --}}
-            <div class="d-none" id="parentLoadedAssets">{{ json_encode(Assets::loaded()) }}</div>
-            @include('crud::inc.form_save_buttons')
+                @if ($crud->model->translationEnabled())
+                    <div class="mb-2 text-right">
+                        {{-- Single button --}}
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown"
+                                    aria-haspopup="true" aria-expanded="false">
+                                {{trans('backpack::crud.language')}}
+                                : {{ $crud->model->getAvailableLocales()[request()->input('_locale')?request()->input('_locale'):App::getLocale()] }}
+                                &nbsp; <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu">
+                                @foreach ($crud->model->getAvailableLocales() as $key => $locale)
+                                    <a class="dropdown-item"
+                                       href="{{ url($crud->route.'/'.$entry->getKey().'/redline') }}?_locale={{ $key }}">{{ $locale }}</a>
+                                @endforeach
+                            </ul>
+                        </div>
+                    </div>
+                @endif
+                {{-- load the view from the application if it exists, otherwise load the one in the package --}}
+                @if(view()->exists('vendor.backpack.crud.form_content'))
+                    @include('vendor.backpack.crud.form_content', ['fields' => $crud->fields(), 'action' => 'redline'])
+                @else
+                    @include('crud::form_content', ['fields' => $crud->fields(), 'action' => 'redline'])
+                @endif
+                {{-- This makes sure that all field assets are loaded. --}}
+                <div class="d-none" id="parentLoadedAssets">{{ json_encode(Assets::loaded()) }}</div>
 
-		  </form>
-	</div>
-</div>
+                <div class="form-group" id="saveActions">
+
+                    <input type="hidden" id="_save_action" name="_save_action">
+
+
+                    <a href="{{ url($crud->route) }}" class="btn btn-default">
+                        <span class="la la-ban"></span>
+                        <span>Cancel</span>
+                    </a>
+
+                    <button type="submit" class="btn btn-primary" data-value="save_and_return_to_projects">
+                        <span class="la la-save" role="presentation" aria-hidden="true" onclick="startAssessment('project')"></span>
+                        <span>Save and Return</span>
+                    </button>
+
+                    <div id="start-principle-assessment-button" class="btn btn-secondary active"
+                         data-value="save_and_start_assessment" onclick="startAssessment('assessment')" disabled>
+                        <span class="la la-arrow-right" role="presentation" aria-hidden="true"></span>
+                        <span>Save and Start Principle Assessment</span>
+                    </div>
+                </div>
+            </form>
+
+        </div>
+    </div>
 @endsection
 
+@push('after_scripts')
+
+    <script>
+
+        // this function checks if form is valid.
+        function checkFormValidity(form) {
+            // the condition checks if `checkValidity` is defined in the form (browser compatibility)
+            if (form[0].checkValidity) {
+                return form[0].checkValidity();
+            }
+            return false;
+        }
+
+        // this function checks if any of the inputs has errors and report them on page.
+        // we use it to report the errors after form validation fails and making the error fields visible
+        function reportValidity(form) {
+            // the condition checks if `reportValidity` is defined in the form (browser compatibility)
+            if (form[0].reportValidity) {
+                // validate and display form errors
+                form[0].reportValidity();
+            }
+        }
+
+        function startAssessment(redirect) {
+            var form = document.getElementById('redlines-form')
+            var saveElement = document.getElementById('_save_action')
+
+            saveElement.value = redirect
+
+            form.requestSubmit()
+
+
+        }
+    </script>
+
+@endpush

--- a/resources/views/vendor/backpack/crud/operations/redline.blade.php
+++ b/resources/views/vendor/backpack/crud/operations/redline.blade.php
@@ -73,7 +73,7 @@
 
                 <div class="form-group" id="saveActions">
 
-                    <input type="hidden" id="_redirect" name="_redirect">
+                    <input type="hidden" id="_redirect" name="_redirect" value="project">
 
 
                     <a href="{{ url($crud->route) }}" class="btn btn-default">
@@ -81,15 +81,15 @@
                         <span>Cancel</span>
                     </a>
 
-                    <button type="submit" class="btn btn-primary" data-value="save_and_return_to_projects"
-                            onclick="startAssessment('project')">
+                    <div class="btn btn-primary active" id="save-and-return-button" data-value="save_and_return_to_projects"
+                            onclick="startAssessment(this, 'project')">
                         <span class="la la-save" role="presentation" aria-hidden="true"></span>
                         <span>Save and Return</span>
-                    </button>
+                    </div>
 
                     <div id="start-principle-assessment-button" class="btn btn-secondary"
                          data-value="save_and_start_assessment"
-                         onclick="startAssessment('{{"assessment/".$entry->getKey()."/assess"}}')" disabled>
+                         onclick="startAssessment(this, '{{"assessment/".$entry->getKey()."/assess"}}')" disabled>
                         <span class="la la-arrow-right" role="presentation" aria-hidden="true"></span>
                         <span>Save and Start Principle Assessment</span>
                     </div>
@@ -123,22 +123,7 @@
             }
         }
 
-        function startAssessment(redirect) {
 
-            // if the form is not complete, do nothing;
-            if (crud.field('redlines_complete').value !== '1') {
-                return;
-            }
-
-            var form = document.getElementById('redlines-form')
-            var redirectElement = document.getElementById('_redirect')
-
-            redirectElement.value = redirect
-
-            form.requestSubmit()
-
-
-        }
     </script>
 
 @endpush

--- a/resources/views/vendor/backpack/crud/operations/redline.blade.php
+++ b/resources/views/vendor/backpack/crud/operations/redline.blade.php
@@ -35,9 +35,9 @@
             <form
                 id="redlines-form"
                 method="post"
-                  action="{{ url($crud->route.'/'.$entry->getKey()).'/redline' }}"
-                  @if ($crud->hasUploadFields('update', $entry->getKey()))
-                      enctype="multipart/form-data"
+                action="{{ url($crud->route.'/'.$entry->getKey()).'/redline' }}"
+                @if ($crud->hasUploadFields('update', $entry->getKey()))
+                    enctype="multipart/form-data"
                 @endif
             >
                 {!! csrf_field() !!}
@@ -73,7 +73,7 @@
 
                 <div class="form-group" id="saveActions">
 
-                    <input type="hidden" id="_redirect" name="_redirect" value="project">
+                    <input type="hidden" id="_redirect" name="_redirect">
 
 
                     <a href="{{ url($crud->route) }}" class="btn btn-default">
@@ -81,13 +81,15 @@
                         <span>Cancel</span>
                     </a>
 
-                    <button type="submit" class="btn btn-primary" data-value="save_and_return_to_projects" onclick="startAssessment('project')">
+                    <button type="submit" class="btn btn-primary" data-value="save_and_return_to_projects"
+                            onclick="startAssessment('project')">
                         <span class="la la-save" role="presentation" aria-hidden="true"></span>
                         <span>Save and Return</span>
                     </button>
 
-                    <div id="start-principle-assessment-button" class="btn btn-secondary active"
-                         data-value="save_and_start_assessment" onclick="startAssessment('{{"assessment/".$entry->getKey()."/assess"}}')" disabled>
+                    <div id="start-principle-assessment-button" class="btn btn-secondary"
+                         data-value="save_and_start_assessment"
+                         onclick="startAssessment('{{"assessment/".$entry->getKey()."/assess"}}')" disabled>
                         <span class="la la-arrow-right" role="presentation" aria-hidden="true"></span>
                         <span>Save and Start Principle Assessment</span>
                     </div>
@@ -122,6 +124,11 @@
         }
 
         function startAssessment(redirect) {
+
+            // if the form is not complete, do nothing;
+            if (crud.field('redlines_complete').value !== '1') {
+                return;
+            }
 
             var form = document.getElementById('redlines-form')
             var redirectElement = document.getElementById('_redirect')


### PR DESCRIPTION
This PR addresses a request to include a link to continue the next stage of the assessment within the current assessment:

### On the Red Flags page

- a new save option is added: "Save and start principle assessment"

This is done by overwriting the default save options within Backpack. Instead, the buttons are included directly in the `redline.blade.php` template. 

- NOTE: the new button is not technically a submit button, but it is linked to some javascript that will update the `_redirect` input value before submitting the form.
- the `_redirect` value is used in the redirect after saving, with a default set in case something goes wrong.

![CleanShot 2023-07-17 at 17 25 01](https://github.com/stats4sd/aec_portfolio/assets/5711101/07e751ae-e245-43c3-bc87-605bf38016a6)


### Principle Assessment

Similar to the red flags, a new option is added to take the user directly to the additional criteria assessment page. This option only appears when the organisation has additional criteria active. It is enabled when the assessment is marked as finalised and disabled when not. 

![CleanShot 2023-07-17 at 17 30 03](https://github.com/stats4sd/aec_portfolio/assets/5711101/784263c3-5159-4478-ac3e-66d626fe63b3)
