### PR TITLE
Get exchange rate data for one year inclusively from free currency API

### DIFF
--- a/app/Jobs/GetHistoricExchangeRates.php
+++ b/app/Jobs/GetHistoricExchangeRates.php
@@ -45,7 +45,7 @@ class GetHistoricExchangeRates implements ShouldQueue
     public function handle(): void
     {
         $startDate = $this->year . '-01-01';
-        $endDate = ($this->year + 1) . '-01-01';
+        $endDate = $this->year . '-12-31';
 
         // if processing the current year, only ask for info up till yesterday (The API cannot get the value for 'today').
         if ($this->year === Carbon::now()->year) {


### PR DESCRIPTION
This PR fixes #110.

Performed testing in local env for year 2011 and year 2012.
2012-01-01 exchange rate data has been retrieved once only.