### PR TITLE
Extra institution + portfolio details

### DIFF
--- a/app/Http/Controllers/Admin/InstitutionTypeCrudController.php
+++ b/app/Http/Controllers/Admin/InstitutionTypeCrudController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Requests\InstitutionTypeRequest;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+/**
+ * Class InstitutionTypeCrudController
+ * @package App\Http\Controllers\Admin
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class InstitutionTypeCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+
+    /**
+     * Configure the CrudPanel object. Apply settings to all operations.
+     * 
+     * @return void
+     */
+    public function setup()
+    {
+        CRUD::setModel(\App\Models\InstitutionType::class);
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/institution-type');
+        CRUD::setEntityNameStrings('institution type', 'institution types');
+    }
+
+    /**
+     * Define what happens when the List operation is loaded.
+     * 
+     * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
+     * @return void
+     */
+    protected function setupListOperation()
+    {
+        
+
+        /**
+         * Columns can be defined using the fluent syntax or array syntax:
+         * - CRUD::column('price')->type('number');
+         * - CRUD::addColumn(['name' => 'price', 'type' => 'number']); 
+         */
+    }
+
+    /**
+     * Define what happens when the Create operation is loaded.
+     * 
+     * @see https://backpackforlaravel.com/docs/crud-operation-create
+     * @return void
+     */
+    protected function setupCreateOperation()
+    {
+        
+
+        /**
+         * Fields can be defined using the fluent syntax or array syntax:
+         * - CRUD::field('price')->type('number');
+         * - CRUD::addField(['name' => 'price', 'type' => 'number'])); 
+         */
+    }
+
+    /**
+     * Define what happens when the Update operation is loaded.
+     * 
+     * @see https://backpackforlaravel.com/docs/crud-operation-update
+     * @return void
+     */
+    protected function setupUpdateOperation()
+    {
+        $this->setupCreateOperation();
+    }
+}

--- a/app/Http/Controllers/Admin/OrganisationCrudController.php
+++ b/app/Http/Controllers/Admin/OrganisationCrudController.php
@@ -47,6 +47,7 @@ class OrganisationCrudController extends CrudController
 
         CRUD::setResponsiveTable(false);
         CRUD::column('name');
+        CRUD::column('institutionType');
         CRUD::column('projects')->type('relationship_count');
     }
 
@@ -57,8 +58,10 @@ class OrganisationCrudController extends CrudController
         }
 
         CRUD::field('name')->label('Enter the Institution name');
-        CRUD::field('name')->label('Enter the Institution\'s default currency')
+        CRUD::field('currency')->label('Enter the Institution\'s default currency')
         ->hint('This currency will be used for the summary dashboard. All initiative budgets for your institution will be converted into this currency');
+        CRUD::field('institutionType')->label('Select the type of institution.');
+        CRUD::field('institution_type_other')->label('Enter the "other" type of institution');
     }
 
     protected function setupUpdateOperation()

--- a/app/Http/Controllers/Admin/PortfolioCrudController.php
+++ b/app/Http/Controllers/Admin/PortfolioCrudController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\GeographicalReach;
+use App\Models\Organisation;
 use App\Models\Portfolio;
 use App\Http\Requests\PortfolioRequest;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
@@ -12,6 +14,7 @@ use Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
 use Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Session;
 use Prologue\Alerts\Facades\Alert;
 
@@ -21,8 +24,12 @@ class PortfolioCrudController extends CrudController
     use ListOperation;
     use CreateOperation;
     use UpdateOperation;
-    use DeleteOperation { destroy as traitDestroy; }
-    use ShowOperation { show as traitShow; }
+    use DeleteOperation {
+        destroy as traitDestroy;
+    }
+    use ShowOperation {
+        show as traitShow;
+    }
 
     use AuthorizesRequests;
 
@@ -66,10 +73,28 @@ class PortfolioCrudController extends CrudController
 
         CRUD::setValidation(PortfolioRequest::class);
 
-        $selectedOrganisationId = Session::get('selectedOrganisationId');
-        CRUD::field('organisation_id')->type('hidden')->default($selectedOrganisationId);
+        $selectedOrganisation = Organisation::find(Session::get('selectedOrganisationId'));
 
-        CRUD::field('name');
+        CRUD::field('organisation_id')->type('hidden')->default($selectedOrganisation->id);
+
+        CRUD::field('name')->label('Enter the name of the portfolio');
+
+
+        CRUD::field('currency-info')
+            ->type('section-title')
+            ->view_namespace('stats4sd.laravel-backpack-section-title::fields')
+            ->title('Currency and Budget')
+            ->content("$selectedOrganisation->name uses $selectedOrganisation->currency as the default currency. When you create initiatives, you will be given the option to choose any currency for the initiative budget, and to find or enter the correct exchange rate. For portfolios, please enter the total budget using the institution's default currency of $selectedOrganisation->currency");
+
+        CRUD::field('budget')
+            ->prefix($selectedOrganisation->currency)
+            ->hint('Enter the overall budget for the portfolio');
+
+        CRUD::field('geographic_reach')
+            ->type('select2_from_array')
+            ->options(Arr::mapWithKeys(GeographicalReach::cases(), fn($enum) => [$enum->value => $enum->value]));
+
+
     }
 
     /**

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -349,7 +349,7 @@ class ProjectCrudController extends CrudController
 
         CRUD::field('geographic_reach')
             ->type('select2_from_array')
-            ->options(Arr::mapWithKeys(GeographicalReach::cases(), fn($enum) => [$enum->name => $enum->value]));
+            ->options(Arr::mapWithKeys(GeographicalReach::cases(), fn($enum) => [$enum->value => $enum->value]));
 
         CRUD::field('continents')->type('relationship')
             ->label('Select the continent / continents that this project works in.')

--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -49,15 +49,15 @@ class OrganisationController extends Controller
     {
         $organisation = Organisation::find(Session::get('selectedOrganisationId'));
 
-
         $validated = $request->validated();
+
         if (!$request->has('has_additional_criteria')) {
             $validated['has_additional_criteria'] = false;
         }
 
         $organisation->update($validated);
 
-        return $organisation;
+        return $organisation->id;
     }
 
     public function export()

--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\GeographicalReach;
 use App\Exports\Assessment\AssessmentExportWorkbook;
 use App\Http\Requests\OrganisationRequest;
 use App\Jobs\ExportOrgData;
+use App\Models\Country;
+use App\Models\InstitutionType;
 use App\Models\Organisation;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Session;
@@ -20,26 +23,41 @@ class OrganisationController extends Controller
 
     public function show()
     {
-        $organisation = Organisation::find(Session::get('selectedOrganisationId'))->load('portfolios.projects');
+        $organisation = Organisation::find(Session::get('selectedOrganisationId'))->load(['portfolios.projects.assessments' => [
+            'failingRedlines',
+            'project.organisation',
+            'principles',
+            ]
+        ]);
+        $institutionTypes = InstitutionType::all();
+        $geographicReaches = GeographicalReach::cases();
+        $countries = Country::all();
 
-        return view('organisations.show', ['organisation' => $organisation]);
+
+        return view('organisations.show', [
+            'organisation' => $organisation,
+            'institutionTypes' => $institutionTypes,
+            'geographicReaches' => $geographicReaches,
+            'countries' => $countries,
+        ]);
 
     }
 
     // can only be used when an organisation is selected in the current session
+    // axios request
     public function update(OrganisationRequest $request)
     {
         $organisation = Organisation::find(Session::get('selectedOrganisationId'));
 
 
         $validated = $request->validated();
-        if(!$request->has('has_additional_criteria')) {
+        if (!$request->has('has_additional_criteria')) {
             $validated['has_additional_criteria'] = false;
         }
 
         $organisation->update($validated);
 
-        return redirect()->route('organisation.self.show');
+        return $organisation;
     }
 
     public function export()

--- a/app/Http/Requests/OrganisationRequest.php
+++ b/app/Http/Requests/OrganisationRequest.php
@@ -26,7 +26,7 @@ class OrganisationRequest extends FormRequest
             'name' => 'required|max:255',
             'currency' => 'required|max:3',
             'has_additional_criteria' => 'sometimes|nullable|bool',
-            'institutionType' => 'required|exists:institution_types,id',
+            'institution_type_id' => 'nullable|exists:institution_types,id',
             'institution_type_other' => 'sometimes|nullable',
             'geographic_reach' => 'sometimes|nullable',
         ];

--- a/app/Http/Requests/OrganisationRequest.php
+++ b/app/Http/Requests/OrganisationRequest.php
@@ -29,6 +29,7 @@ class OrganisationRequest extends FormRequest
             'institution_type_id' => 'nullable|exists:institution_types,id',
             'institution_type_other' => 'sometimes|nullable',
             'geographic_reach' => 'sometimes|nullable',
+            'hq_country' => 'nullable|exists:countries,id',
         ];
     }
 }

--- a/app/Http/Requests/OrganisationRequest.php
+++ b/app/Http/Requests/OrganisationRequest.php
@@ -26,6 +26,9 @@ class OrganisationRequest extends FormRequest
             'name' => 'required|max:255',
             'currency' => 'required|max:3',
             'has_additional_criteria' => 'sometimes|nullable|bool',
+            'institutionType' => 'required|exists:institution_types,id',
+            'institution_type_other' => 'sometimes|nullable',
+            'geographic_reach' => 'sometimes|nullable',
         ];
     }
 }

--- a/app/Http/Requests/PortfolioRequest.php
+++ b/app/Http/Requests/PortfolioRequest.php
@@ -25,7 +25,9 @@ class PortfolioRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|max:255'
+            'name' => 'required|max:255',
+            'currency' => 'nullable',
+            'budget' => 'nullable',
         ];
     }
 

--- a/app/Http/Requests/PortfolioRequest.php
+++ b/app/Http/Requests/PortfolioRequest.php
@@ -27,7 +27,7 @@ class PortfolioRequest extends FormRequest
         return [
             'name' => 'required|max:255',
             'currency' => 'nullable',
-            'budget' => 'nullable',
+            'budget' => 'nullable|gte:0|max:18446744073709551615',
         ];
     }
 

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -43,7 +43,7 @@ class ProjectRequest extends FormRequest
             'main_recipient' => 'required',
             'start_date' => 'required',
             'end_date' => 'nullable|after:start_date',
-            'geographic_reach' => ['required', Rule::in(collect(GeographicalReach::cases())->pluck('name')->toArray())],
+            'geographic_reach' => ['required', Rule::in(collect(GeographicalReach::cases())->pluck('value')->toArray())],
             'continents' => 'required',
             'regions' => 'required',
             'countries' => 'required',

--- a/app/Models/InstitutionType.php
+++ b/app/Models/InstitutionType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class InstitutionType extends Model
+{
+    use CrudTrait;
+
+    /*
+    |--------------------------------------------------------------------------
+    | GLOBAL VARIABLES
+    |--------------------------------------------------------------------------
+    */
+
+    protected $table = 'institution_types';
+    protected $guarded = ['id'];
+
+    public function organisations(): HasMany
+    {
+        return $this->hasMany(Organisation::class);
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\AssessmentStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
@@ -131,5 +132,10 @@ class Organisation extends Model
             DB::insert('insert into role_invites (email, role_id, inviter_id, token, created_at, updated_at) values (?, ?, ?, ?, NOW(), NOW())',
                 [$email, $roleId, auth()->user()->id, $invite->token]);
         }
+    }
+
+    public function institutionType(): BelongsTo
+    {
+        return $this->belongsTo(InstitutionType::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,9 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Notifications\Notifiable;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
@@ -53,5 +56,13 @@ class User extends Authenticatable
     public function isAdmin()
     {
         return $this->hasAnyRole('Site Admin');
+    }
+
+    public function withPermissionNames()
+    {
+        $this->permission_names = $this->roles->map(fn(Role $role): ?Collection => $role->permissions)
+            ->flatten()
+            ->map(fn(Permission $permission): string => $permission->name);
+        return $this;
     }
 }

--- a/database/factories/OrganisationFactory.php
+++ b/database/factories/OrganisationFactory.php
@@ -2,6 +2,10 @@
 
 namespace Database\Factories;
 
+use App\Enums\GeographicalReach;
+use App\Models\Country;
+use App\Models\Currency;
+use App\Models\InstitutionType;
 use App\Models\Organisation;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
@@ -12,8 +16,20 @@ class OrganisationFactory extends Factory
 
     public function definition(): array
     {
+        $institutionType = $this->faker->randomElement(InstitutionType::all()->pluck('id')->toArray());
+        if ($institutionType === 5) {
+            $institutionTypeOther = $this->faker->text();
+        } else {
+            $institutionTypeOther = null;
+        }
+
         return [
             'name' => $this->faker->company,
+            'currency' => $this->faker->randomElement(Currency::all()->pluck('id')->toArray()),
+            'institution_type_id' => $institutionType,
+            'institution_type_other' => $institutionTypeOther,
+            'hq_country' => $this->faker->randomElement(Country::all()->pluck('id')->toArray()),
+            'geographic_reach' => $this->faker->randomElement(GeographicalReach::cases()),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ];

--- a/database/factories/PortfolioFactory.php
+++ b/database/factories/PortfolioFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\GeographicalReach;
 use App\Models\Organisation;
 use App\Models\Portfolio;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -15,10 +16,12 @@ class PortfolioFactory extends Factory
     {
         return [
             'name' => $this->faker->catchPhrase(),
+            'organisation_id' => Organisation::factory(),
+            'budget' => $this->faker->randomNumber(),
+            'currency' => $this->faker->currencyCode(),
+            'geographic_reach' => $this->faker->randomElement(GeographicalReach::cases()),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
-
-            'organisation_id' => Organisation::factory(),
         ];
     }
 }

--- a/database/migrations/2023_07_18_104722_create_institution_types_table.php
+++ b/database/migrations/2023_07_18_104722_create_institution_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('institution_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('parent_id')->nullable()->default(0);
+            $table->integer('lft')->default(0);
+            $table->integer('rgt')->default(0);
+            $table->integer('depth')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('institution_types');
+    }
+};

--- a/database/migrations/2023_07_18_105214_add_extra_details_to_organisations_table.php
+++ b/database/migrations/2023_07_18_105214_add_extra_details_to_organisations_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->foreignId('institution_type_id')
+                ->nullable()
+                ->constrained('institution_types')
+                ->nullOnDelete()
+                ->cascadeOnUpdate();
+
+            $table->string('institution_type_other')->nullable();
+
+            $table->string('hq_country')
+                ->nullable()
+                ->constrained('countries')
+                ->nullOnDelete()
+                ->cascadeOnUpdate();
+
+            $table->string('geographic_reach')->nullable();
+            $table->text('description')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2023_07_18_105223_add_extra_details_to_portfolios_table.php
+++ b/database/migrations/2023_07_18_105223_add_extra_details_to_portfolios_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('portfolios', function (Blueprint $table) {
+            $table->unsignedBigInteger('budget')->nullable();
+            $table->string('currency')->nullable();
+            $table->decimal('exchange_rate', 10, 6)->nullable();
+            $table->string('geographic_reach')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('portfolios', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
         $this->call(RedLinesTableSeeder::class);
         $this->call(PrinciplesTableSeeder::class);
         $this->call(InitiativeCategorySeeder::class);
+        $this->call(InstitutionTypeSeeder::class);
         $this->call(TestSeeder::class);
         $this->call(DashboardRatingSeeder::class);
         $this->call(ProjectSeeder::class);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(ContinentSeeder::class);
+        $this->call(CurrencySeeder::class);
         $this->call(RoleSeeder::class);
         $this->call(RedLinesTableSeeder::class);
         $this->call(PrinciplesTableSeeder::class);

--- a/database/seeders/InstitutionTypeSeeder.php
+++ b/database/seeders/InstitutionTypeSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\InstitutionType;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class InstitutionTypeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        InstitutionType::create(['name' => 'NGO']);
+        InstitutionType::create(['name' => 'Government']);
+        InstitutionType::create(['name' => 'University']);
+        InstitutionType::create(['name' => 'For-profit corporation']);
+        InstitutionType::create(['name' => 'Other']);
+    }
+}

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -33,7 +33,10 @@ class TestSeeder extends Seeder
 
         $institution = Organisation::create([
             'name' => 'Test Institution 1',
+            'geographic_reach' => GeographicalReach::Global->value,
+            'currency' => 'EUR',
             'has_additional_criteria' => 0,
+            'description' => 'This is a test organisation',
         ]);
 
         $portfolio = $institution->portfolios()->create([

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,3 +7,5 @@ window._ = _;
 window.axios = axios;
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 window.swal = Swal;
+
+console.log('hi');

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -40,7 +40,7 @@
                 <div class="col-sm-8 offset-sm-4">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="additional_criteria_check"
-                               name="has_additional_criteria" v-model="institution.has_additional_criteria">
+                               name="has_additional_criteria" v-model="institution.has_additional_criteria" :value="1">
                         <label class="form-check-label" for="additional_criteria_check">
                             This Institution uses additional assessment criteria
                         </label>

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -3,7 +3,6 @@
 
         <h2>Institution Details</h2>
         <p class="help-block">Add or edit the relevant information for the institution.</p>
-
     </div>
 
     <div class="card-body">
@@ -16,6 +15,7 @@
                            class="form-control"
                            id="input_name"
                            v-model="institution.name"
+                           :disabled="!canEdit"
                     >
                     <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('name')">
                             <strong v-for="error in errors.name">{{ error }}</strong><br/>
@@ -27,7 +27,14 @@
                 <label for="input_currency" class="col-sm-4 col-form-label text-right pr-2">Main Currency (3-letter
                     code)</label>
                 <div class="col-sm-8 col-lg-4">
-                    <input name="currency" class="form-control" id="input_currency" v-model="institution.currency">
+                    <input
+                        name="currency"
+                        class="form-control"
+                        id="input_currency"
+                        v-model="institution.currency"
+                        :disabled="!canEdit"
+
+                    >
                     <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('currency')">
                             <strong v-for="error in errors.currency">{{ error }}</strong><br/>
                         </span>
@@ -39,12 +46,20 @@
             <div class="form-group row">
                 <div class="col-sm-8 offset-sm-4">
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" id="additional_criteria_check"
-                               name="has_additional_criteria" v-model="institution.has_additional_criteria" :value="1">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            id="additional_criteria_check"
+                            name="has_additional_criteria"
+                            v-model="institution.has_additional_criteria"
+                            :value="1"
+                            :disabled="!canEdit"
+                        >
                         <label class="form-check-label" for="additional_criteria_check">
                             This Institution uses additional assessment criteria
                         </label>
-                        <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('has_additional_criteria')">
+                        <span class="text-danger emphasis show" role="alert"
+                              v-if="errors.hasOwnProperty('has_additional_criteria')">
                             <strong v-for="error in errors.has_additional_criteria">{{ error }}</strong><br/>
                         </span>
                     </div>
@@ -70,9 +85,11 @@
                         :options="institutionTypes"
                         label="name"
                         :reduce="institutionType => institutionType.id"
+                        :disabled="!canEdit"
 
                     />
-                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('institution_type_id')">
+                    <span class="text-danger emphasis show" role="alert"
+                          v-if="errors.hasOwnProperty('institution_type_id')">
                             <strong v-for="error in errors.institution_type_id">{{ error }}</strong><br/>
                         </span>
                     <small id="institution_type_help" class="form-text font-sm">This can be used as an additional
@@ -89,9 +106,10 @@
                            class="form-control"
                            id="institution_type_other"
                            v-model="institution.institution_type_other"
-                           :disabled="institution.institution_type_id !== 5"
+                           :disabled="institution.institution_type_id !== 5 || !canEdit"
                     >
-                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('institution_type_other')">
+                    <span class="text-danger emphasis show" role="alert"
+                          v-if="errors.hasOwnProperty('institution_type_other')">
                         <strong v-for="error in errors.institution_type_other">{{ error }}</strong><br/>
                     </span>
                 </div>
@@ -106,8 +124,10 @@
                         id="input_geographic_reach"
                         v-model="institution.geographic_reach"
                         :options="geographicReaches"
+                        :disabled="!canEdit"
                     />
-                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('geographic_reach')">
+                    <span class="text-danger emphasis show" role="alert"
+                          v-if="errors.hasOwnProperty('geographic_reach')">
                             <strong v-for="error in errors.geographic_reach">{{ error }}</strong><br/>
                     </span>
                 </div>
@@ -124,6 +144,7 @@
                         label="name"
                         :reduce="country => country.id"
                         v-model="institution.hq_country"
+                        :disabled="!canEdit"
                     />
                     <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('hq_country')">
                             <strong v-for="error in errors.hq_country">{{ error }}</strong><br/>
@@ -132,7 +153,7 @@
             </div>
 
             <div class="form-group d-flex justify-content-end mt-16"
-                 v-if="user.permission_names.includes('edit own institution')">
+                 v-if="canEdit">
                 <button type="cancel" class="btn btn-secondary mr-4">Discard Changes</button>
                 <button type="submit" class="btn btn-primary" @click="save">Save</button>
             </div>
@@ -143,7 +164,7 @@
 
 <script setup>
 
-import {onMounted, ref} from "vue";
+import {onMounted, ref, computed} from "vue";
 import 'vue-select/dist/vue-select.css';
 import vSelect from 'vue-select'
 
@@ -159,6 +180,8 @@ const props = defineProps({
 
 const errors = ref({})
 const institution = ref({});
+
+const canEdit = computed(() => props.user.permission_names.includes('edit own institution'))
 
 
 onMounted(() => {

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -1,0 +1,183 @@
+<template>
+    <div class="card-header">
+
+        <h2>Institution Details</h2>
+        <p class="help-block">Add or edit the relevant information for the institution.</p>
+
+    </div>
+
+    <div class="card-body">
+        <form>
+
+            <div class="form-group row mt-16">
+                <label for="input_name" class="col-sm-4 col-form-label text-right pr-2">Institution Name</label>
+                <div class="col-sm-8">
+                    <input name="name"
+                           class="form-control"
+                           id="input_name"
+                           v-model="institution.name"
+                    >
+                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('name')">
+                            <strong v-for="error in errors.name">{{ error }}</strong><br/>
+                        </span>
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label for="input_currency" class="col-sm-4 col-form-label text-right pr-2">Main Currency (3-letter
+                    code)</label>
+                <div class="col-sm-8 col-lg-4">
+                    <input name="currency" class="form-control" id="input_currency" v-model="institution.currency">
+                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('currency')">
+                            <strong v-for="error in errors.currency">{{ error }}</strong><br/>
+                        </span>
+                    <small id="currencyHelp" class="form-text font-sm">This currency will be used for the summary
+                        dashboard. All initiative budgets for your institution will be converted into this
+                        currency.</small>
+                </div>
+            </div>
+            <div class="form-group row">
+                <div class="col-sm-8 offset-sm-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="additional_criteria_check"
+                               name="has_additional_criteria" v-model="institution.has_additional_criteria">
+                        <label class="form-check-label" for="additional_criteria_check">
+                            This Institution uses additional assessment criteria
+                        </label>
+                        <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('has_additional_criteria')">
+                            <strong v-for="error in errors.has_additional_criteria">{{ error }}</strong><br/>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            <hr/>
+            <div class="form-group row">
+                <div class="col-sm-4">
+                    <h3>Optional Information</h3>
+                    <p>Adding additional information will help improve the analysis of anonymised results.</p>
+                </div>
+            </div>
+            <hr/>
+
+            <div class="form-group row">
+                <label for="input_type" class="col-sm-4 col-form-label text-right pr-2">Select the Institution
+                    Type</label>
+                <div class="col-sm-8 col-lg-4">
+                    <v-select
+                        name="institution_type"
+                        id="input_type"
+                        v-model="institution.institution_type_id"
+                        :options="institutionTypes"
+                        label="name"
+                        :reduce="institutionType => institutionType.id"
+
+                    />
+                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('institution_type_id')">
+                            <strong v-for="error in errors.institution_type_id">{{ error }}</strong><br/>
+                        </span>
+                    <small id="institution_type_help" class="form-text font-sm">This can be used as an additional
+                        disaggregation for
+                        analysis of funding flows.</small>
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label for="input_institution_type_other" class="col-sm-4 col-form-label text-right pr-2">Enter the
+                    'other' institution type:</label>
+                <div class="col-sm-8 col-lg-4">
+                    <input name="institution_type_other"
+                           class="form-control"
+                           id="institution_type_other"
+                           v-model="institution.institution_type_other"
+                           :disabled="institution.institution_type_id !== 5"
+                    >
+                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('institution_type_other')">
+                        <strong v-for="error in errors.institution_type_other">{{ error }}</strong><br/>
+                    </span>
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label for="input_geographic_reach" class="col-sm-4 col-form-label text-right pr-2">What is the
+                    geographic reach of the institution?</label>
+                <div class="col-sm-8 col-lg-4">
+                    <v-select
+                        name="geographic_reach"
+                        id="input_geographic_reach"
+                        v-model="institution.geographic_reach"
+                        :options="geographicReaches"
+                    />
+                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('geographic_reach')">
+                            <strong v-for="error in errors.geographic_reach">{{ error }}</strong><br/>
+                    </span>
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label for="input_hq_country" class="col-sm-4 col-form-label text-right pr-2">What country is the
+                    institution HQ based?</label>
+                <div class="col-sm-8 col-lg-4">
+                    <v-select
+                        name="hq_country"
+                        id="input_hq_country"
+                        :options="countries"
+                        label="name"
+                        :reduce="country => country.id"
+                        v-model="institution.hq_country"
+                    />
+                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('hq_country')">
+                            <strong v-for="error in errors.hq_country">{{ error }}</strong><br/>
+                        </span>
+                </div>
+            </div>
+
+            <div class="form-group d-flex justify-content-end mt-16"
+                 v-if="user.permission_names.includes('edit own institution')">
+                <button type="cancel" class="btn btn-secondary mr-4">Discard Changes</button>
+                <button type="submit" class="btn btn-primary" @click="save">Save</button>
+            </div>
+        </form>
+    </div>
+
+</template>
+
+<script setup>
+
+import {onMounted, ref} from "vue";
+import 'vue-select/dist/vue-select.css';
+import vSelect from 'vue-select'
+
+
+const props = defineProps({
+    initInstitution: Object,
+    institutionTypes: Array,
+    geographicReaches: Array,
+    countries: Array,
+    updateRoute: String,
+    user: Object,
+})
+
+const errors = ref({})
+const institution = ref({});
+
+
+onMounted(() => {
+    institution.value = {...props.initInstitution}
+})
+
+async function save() {
+
+    try {
+        const result = await axios.put(props.updateRoute, institution.value)
+    } catch (error) {
+        errors.value = error.response?.data.errors ?? null
+    }
+
+    new Noty({
+        type: "success",
+        text: "The Institution data was successfully saved"
+    }).show();
+}
+
+
+</script>

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -6,8 +6,6 @@
     </div>
 
     <div class="card-body">
-        <form>
-
             <div class="form-group row mt-16">
                 <label for="input_name" class="col-sm-4 col-form-label text-right pr-2">Institution Name</label>
                 <div class="col-sm-8">
@@ -155,9 +153,9 @@
             <div class="form-group d-flex justify-content-end mt-16"
                  v-if="canEdit">
                 <button type="cancel" class="btn btn-secondary mr-4">Discard Changes</button>
-                <button type="submit" class="btn btn-primary" @click="save">Save</button>
+                <button class="btn btn-primary" @click="save">Save</button>
             </div>
-        </form>
+
     </div>
 
 </template>

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -168,9 +168,13 @@ onMounted(() => {
 async function save() {
 
     try {
-        const result = await axios.put(props.updateRoute, institution.value)
+        const result = await axios.post(props.updateRoute, institution.value)
+
+        console.log(result)
     } catch (error) {
-        errors.value = error.response?.data.errors ?? null
+
+        console.log(error)
+        errors.value = error.response?.data.errors ?? {}
     }
 
     new Noty({

--- a/resources/js/institutions.js
+++ b/resources/js/institutions.js
@@ -1,8 +1,9 @@
 import {createApp} from 'vue/dist/vue.esm-bundler';
 
 import InstitutionSettings from "./components/InstitutionSettings.vue"
-
+import {Suspense} from "vue";
 
 createApp()
     .component('InstitutionSettings', InstitutionSettings)
+    .component('Suspense', Suspense)
     .mount('#org-settings')

--- a/resources/js/institutions.js
+++ b/resources/js/institutions.js
@@ -1,0 +1,8 @@
+import {createApp} from 'vue/dist/vue.esm-bundler';
+
+import InstitutionSettings from "./components/InstitutionSettings.vue"
+
+
+createApp()
+    .component('InstitutionSettings', InstitutionSettings)
+    .mount('#org-settings')

--- a/resources/views/organisations/portfolios.blade.php
+++ b/resources/views/organisations/portfolios.blade.php
@@ -9,6 +9,8 @@
         <thead>
         <tr>
             <th scope="col">Portfolio Name</th>
+            <th scope="col">Budget</th>
+            <th scope="col">Geographic Reach</th>
             <th scope="col"># of Initiatives</th>
             <th scope="col"># of Fully Assessed Initiatives</th>
             <th scope="col">Actions</th>
@@ -21,6 +23,8 @@
                     <td>
                         {{ $portfolio->name }}
                     </td>
+                    <td>{{ $organisation->currency }} {{ $portfolio->budget }}</td>
+                    <td>{{ $portfolio->geographic_reach }}</td>
                     <td>{{ $portfolio->projects->count() }}</td>
                     <td>{{ $portfolio->projects->filter(fn(\App\Models\Project $initiative): bool => $initiative->latest_assessment->completed_at !== null)->count() }}</td>
                     <td>

--- a/resources/views/organisations/show.blade.php
+++ b/resources/views/organisations/show.blade.php
@@ -52,14 +52,16 @@
             @endif
             <div class="tab-pane fade show active" role="tabpanel" aria-labelledby="settings-tab" id="settings">
                 <div id="org-settings">
-                    <institution-settings
-                        :init-institution="{{ $organisation }}"
-                        :institution-types="{{ $institutionTypes->toJson() }}"
-                        :geographic-reaches="{{ json_encode($geographicReaches) }}"
-                        :countries="{{ $countries->toJson() }}"
-                        update-route="{{ route('organisation.self.update') }}"
-                        :user="{{ Auth::user()->withPermissionNames() }}"
-                    />
+                    <Suspense>
+                        <institution-settings
+                            :init-institution="{{ $organisation }}"
+                            :institution-types="{{ $institutionTypes->toJson() }}"
+                            :geographic-reaches="{{ json_encode($geographicReaches) }}"
+                            :countries="{{ $countries->toJson() }}"
+                            update-route="{{ route('organisation.self.update') }}"
+                            :user="{{ Auth::user()->withPermissionNames() }}"
+                        />
+                    </Suspense>
                 </div>
             </div>
         </div>

--- a/resources/views/organisations/show.blade.php
+++ b/resources/views/organisations/show.blade.php
@@ -10,24 +10,30 @@
 
         <ul class="nav nav-tabs mt-4" id="org-tabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <a href="#members" class="nav-link px-8 org-tab" id="members-tab" data-toggle="tab" data-target="#members" type="button" role="tab" aria-controls="home" aria-selected="true">
+                <a href="#members" class="nav-link px-8 org-tab" id="members-tab" data-toggle="tab"
+                   data-target="#members" type="button" role="tab" aria-controls="home" aria-selected="true">
                     <h5 class="text-uppercase m-0 p-0">Users</h5>
                 </a>
             </li>
             <li class="nav-item" role="presentation">
-                <a href="#portfolios" class="nav-link px-8 org-tab" id="portfolios-tab" data-toggle="tab" data-target="#portfolios" type="button" role="tab" aria-controls="home" aria-selected="true">
+                <a href="#portfolios" class="nav-link px-8 org-tab" id="portfolios-tab" data-toggle="tab"
+                   data-target="#portfolios" type="button" role="tab" aria-controls="home" aria-selected="true">
                     <h5 class="text-uppercase m-0 p-0">Portfolios</h5>
                 </a>
             </li>
             @if($organisation->has_additional_criteria)
                 <li class="nav-item" role="presentation">
-                    <a href="#additional-criteria" class="nav-link px-8 org-tab" id="additional-criteria-tab" data-toggle="tab" data-target="#additional-criteria" type="button" role="tab" aria-controls="home" aria-selected="true">
+                    <a href="#additional-criteria" class="nav-link px-8 org-tab" id="additional-criteria-tab"
+                       data-toggle="tab" data-target="#additional-criteria" type="button" role="tab"
+                       aria-controls="home" aria-selected="true">
                         <h5 class="text-uppercase m-0 p-0">Additional Assessment Criteria</h5>
                     </a>
                 </li>
             @endif
             <li class="nav-item" role="presentation">
-                <a href="#settings" class="nav-link px-8 org-tab active" id="settings-tab" data-toggle="tab" data-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false"><h5 class="text-uppercase m-0 p-0">Settings</h5>
+                <a href="#settings" class="nav-link px-8 org-tab active" id="settings-tab" data-toggle="tab"
+                   data-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false"><h5
+                        class="text-uppercase m-0 p-0">Settings</h5>
                 </a>
             </li>
         </ul>
@@ -39,12 +45,22 @@
                 @include('organisations.portfolios')
             </div>
             @if($organisation->has_additional_criteria)
-                <div class="tab-pane fade" id="additional-criteria" role="tabpanel" aria-labelledby="additional-criteria-tab-tab">
+                <div class="tab-pane fade" id="additional-criteria" role="tabpanel"
+                     aria-labelledby="additional-criteria-tab-tab">
                     @include('organisations.additional-criteria')
                 </div>
             @endif
-            <div class="tab-pane fade show active" id="settings" role="tabpanel" aria-labelledby="settings-tab">
-                @include('organisations.settings')
+            <div class="tab-pane fade show active" role="tabpanel" aria-labelledby="settings-tab" id="settings">
+                <div id="org-settings">
+                    <institution-settings
+                        :init-institution="{{ $organisation }}"
+                        :institution-types="{{ $institutionTypes->toJson() }}"
+                        :geographic-reaches="{{ json_encode($geographicReaches) }}"
+                        :countries="{{ $countries->toJson() }}"
+                        update-route="{{ route('organisation.self.update') }}"
+                        :user="{{ Auth::user()->withPermissionNames() }}"
+                    />
+                </div>
             </div>
         </div>
 
@@ -53,7 +69,7 @@
 @endsection
 
 @section('after_scripts')
-    @vite('resources/js/app.js')
+    @vite(['resources/js/app.js', 'resources/js/institutions.js'])
 
 
     <script>

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -136,3 +136,4 @@ E.g., Centralise instituion selection to a single feature instead of distributin
 @endif
 
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('initiative-category') }}"><i class="nav-icon la la-question"></i> Initiative categories</a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('institution-type') }}"><i class="nav-icon la la-question"></i> Institution types</a></li>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Admin\AssessmentCrudController;
 use App\Http\Controllers\Admin\ContinentCrudController;
 use App\Http\Controllers\Admin\CountryCrudController;
 use App\Http\Controllers\Admin\InitiativeCategoryCrudController;
+use App\Http\Controllers\Admin\InstitutionTypeCrudController;
 use App\Http\Controllers\Admin\OrganisationCrudController;
 use App\Http\Controllers\Admin\PortfolioCrudController;
 use App\Http\Controllers\Admin\PrincipleCrudController;
@@ -136,8 +137,8 @@ Route::group([
 
 
     Route::crud('initiative-category', InitiativeCategoryCrudController::class);
+    Route::crud('institution-type', InstitutionTypeCrudController::class);
 });
-// for use with Browsershot:
 
 Route::get('project/{id}/show-as-pdf', [ProjectCrudController::class, 'show'])
     ->middleware('auth.basic')

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@ Route::get(config('backpack.base.route_prefix') . '/login', function () {
 });
 
 
-Route::put('organisation/update', [OrganisationController::class, 'update'])->name('organisation.self.update');
+Route::post('organisation/update', [OrganisationController::class, 'update'])->name('organisation.self.update');
 
 
 // `API` calls for Vue components

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
                 'resources/js/radarChart.js',
                 'resources/js/dashboard.js',
                 'resources/js/initiatives.js',
+                'resources/js/institutions.js',
                 'resources/js/assess.js',
                 'resources/js/dashboard-temp.js',
             ],


### PR DESCRIPTION
fixes #146.

This PR adds the required extra information to portfolios and organisations, as per the technical specification.

### Updates
- The database + seeders / factories are updated with the new fields
- The portfolio table view now includes budget and geographic reach
- Creating / editing portfolios via the CRUD panel controller has the extra fields:
  - NOTE: I chose to only allow portfolio budgets in the institution's default currency, for simplicity. Given we do not have a clear start date for a portfolio (as with an initiative), I don't know how much sense it would be to give a single exchange rate for conversion. If this becomes an issue,  I think it is a V2.0 feature. 

- Editing institution details is now via a Vue component, and includes the extra relevant fields. 
- Users without the "edit own institution" permission will see the fields as disabled. 


The tech specs were not fully clear on whether institutions and portfolios should be linkable to continents/regions/countries. I chose to not do this, but am open to this being a requested feature if it is deemed to be vital. 

This PR also adds InstitutionType as a new data model, linked to institutions. 
 