### PR TITLE
enable telescope in production for site admins

### DIFF
--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -64,7 +64,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
     protected function gate()
     {
         Gate::define('viewTelescope', function ($user) {
-            return in_array($user->email, User::all()->filter(fn($user) => $user->isAdmin() ));
+            return in_array($user->email, User::all()->filter(fn($user) => $user->isAdmin() )->pluck('email')->toArray());
         });
     }
 }


### PR DESCRIPTION
This PR allows site admins to review the Laravel Telescope logs in production environments. 