### PR TITLE
Remove global scope from relationship call

### DIFF
--- a/app/Models/Assessment.php
+++ b/app/Models/Assessment.php
@@ -78,7 +78,8 @@ class Assessment extends Model
 
     public function project()
     {
-        return $this->belongsTo(Project::class);
+        return $this->belongsTo(Project::class)
+         ->withoutGlobalScope('organisation');
     }
 
     public function customScoreTags(): HasMany


### PR DESCRIPTION
fixes #156.

The issue was that the PDF generation doesn't use the current session, so there is no selected organisation. The assessment calls the `project` relationship to check for the existence of additiopnal criteria. It was failing to find the project because of the global scope. 

This PR removes the global scope from the relationship call. It doesn't affect other parts because it's assumed that once you have access to the assessment, you should always be able to access the parent project. 

