### PR TITLE
Add User feedback

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -30,6 +30,8 @@ class Kernel extends ConsoleKernel
         $schedule->command('senddataremovalreminderemail')->dailyAt('00:11');
 
         $schedule->command('app:remove-old-pdf-prints')->weeklyOn('sunday', '01:00');
+
+        $schedule->command('media-library:delete-old-temporary-uploads')->daily();
     }
 
     /**

--- a/app/Http/Controllers/Admin/AdditionalCriteriaCrudController.php
+++ b/app/Http/Controllers/Admin/AdditionalCriteriaCrudController.php
@@ -103,7 +103,7 @@ class AdditionalCriteriaCrudController extends CrudController
             ->hint('This could be a link to your own institutional website, or to external information if this assessment criteria is used by multiple institutions.');
 
         CRUD::field('rating_description_header')
-            ->type('section-title')
+            ->type('    section-title')
             ->title('What do the ratings mean?')
             ->content('Each project or initiative will be given a score of 0 - 2 for this assessment criterium. Below, please enter a brief description of what a rating of 0, 1 or 2 means. This will help harmonise the rating process and let different users give scores that are comparable.')
             ->view_namespace('stats4sd.laravel-backpack-section-title::fields');

--- a/app/Http/Controllers/Admin/UserFeedbackCrudController.php
+++ b/app/Http/Controllers/Admin/UserFeedbackCrudController.php
@@ -16,8 +16,6 @@ class UserFeedbackCrudController extends CrudController
 {
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
-    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
-    use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
 
     /**
      * Configure the CrudPanel object. Apply settings to all operations.
@@ -40,13 +38,17 @@ class UserFeedbackCrudController extends CrudController
     protected function setupListOperation()
     {
 
+        CRUD::column('type.name');
         CRUD::column('user.email');
         CRUD::column('created_at');
-        CRUD::column('status');
+        CRUD::column('');
 
         CRUD::enableDetailsRow();
-
         CRUD::setDetailsRowView('user-feedback.details_row');
+
+        if(!Auth::user()->can('manage user feedback')) {
+            CRUD::denyAccess(['list', 'update']);
+        }
 
     }
 
@@ -55,20 +57,41 @@ class UserFeedbackCrudController extends CrudController
 
         CRUD::field('title')
             ->type('section-title')
-            ->title('Add Your Feedback')
-            ->content('Please enter the details below.<br/><br/>
-                    If you are reporting a bug, please tell us what page you were on, what you expected to happen, and what actually happened. If possible, please include a screenshot, as they are very helpful for us to identify the issue.
-                   <br/><br/>
-                   If you are making a suggestion, please let us know what feature or addition you would like to see. We may get in touch with you for more information. Please tell us if you do <span class="font-weight-bold">Not</span> want us to do that below.
-                    ')
+            ->title('Feedback Details')
             ->view_namespace('stats4sd.laravel-backpack-section-title::fields');
 
-        CRUD::field('user')->type('hidden')->value(Auth::id());
+        CRUD::field('user')->attributes(['disabled' => 'disabled']);
 
-        CRUD::field('feedbackType')->label('What type of feedback is this?');
-        CRUD::field('text')->type('text')->label('Describe the issue:');
-        CRUD::field('uploads')->type('upload_multiple')->label('If you have screenshots or supporting files, please upload them here.');
 
+        CRUD::field('userFeedbackType')->attributes(['disabled' => 'disabled']);
+        CRUD::field('message')->type('textarea')->attributes(['readonly' => 'readonly']);
+
+        CRUD::field('title')
+            ->type('section-title')
+            ->content('Add / edit manager comments below')
+            ->view_namespace('stats4sd.laravel-backpack-section-title::fields');
+
+        CRUD::field('comments')
+        ->subfields([
+            [
+                'name' => 'user',
+                'type' => 'relationship',
+                'default' => Auth::user(),
+                'attributes' => ['disabled' => 'disabled'],
+            ],
+            [
+                'name' => 'user_id',
+                'type' => 'hidden',
+                'default' => Auth::user()->id,
+            ],
+            [
+                'name' => 'message',
+                'type' => 'textarea',
+                'attributes' => [
+                    'readonly' =>
+                ]
+            ],
+        ]);
 
 
     }

--- a/app/Http/Controllers/Admin/UserFeedbackCrudController.php
+++ b/app/Http/Controllers/Admin/UserFeedbackCrudController.php
@@ -87,9 +87,6 @@ class UserFeedbackCrudController extends CrudController
             [
                 'name' => 'message',
                 'type' => 'textarea',
-                'attributes' => [
-                    'readonly' =>
-                ]
             ],
         ]);
 

--- a/app/Http/Controllers/Admin/UserFeedbackCrudController.php
+++ b/app/Http/Controllers/Admin/UserFeedbackCrudController.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Facades\Auth;
 class UserFeedbackCrudController extends CrudController
 {
     use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
-    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
@@ -51,13 +50,7 @@ class UserFeedbackCrudController extends CrudController
 
     }
 
-    /**
-     * Define what happens when the Create operation is loaded.
-     *
-     * @see https://backpackforlaravel.com/docs/crud-operation-create
-     * @return void
-     */
-    protected function setupCreateOperation()
+    protected function setupUpdateOperation()
     {
 
         CRUD::field('title')
@@ -80,14 +73,5 @@ class UserFeedbackCrudController extends CrudController
 
     }
 
-    /**
-     * Define what happens when the Update operation is loaded.
-     *
-     * @see https://backpackforlaravel.com/docs/crud-operation-update
-     * @return void
-     */
-    protected function setupUpdateOperation()
-    {
-        $this->setupCreateOperation();
-    }
+
 }

--- a/app/Http/Controllers/Admin/UserFeedbackCrudController.php
+++ b/app/Http/Controllers/Admin/UserFeedbackCrudController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Requests\UserFeedbackRequest;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Class UserFeedbackCrudController
+ * @package App\Http\Controllers\Admin
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class UserFeedbackCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+
+    /**
+     * Configure the CrudPanel object. Apply settings to all operations.
+     *
+     * @return void
+     */
+    public function setup()
+    {
+        CRUD::setModel(\App\Models\UserFeedback::class);
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/user-feedback');
+        CRUD::setEntityNameStrings('user feedback', 'user feedbacks');
+    }
+
+    /**
+     * Define what happens when the List operation is loaded.
+     *
+     * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
+     * @return void
+     */
+    protected function setupListOperation()
+    {
+
+        CRUD::column('user.email');
+        CRUD::column('created_at');
+        CRUD::column('status');
+
+        CRUD::enableDetailsRow();
+
+        CRUD::setDetailsRowView('user-feedback.details_row');
+
+    }
+
+    /**
+     * Define what happens when the Create operation is loaded.
+     *
+     * @see https://backpackforlaravel.com/docs/crud-operation-create
+     * @return void
+     */
+    protected function setupCreateOperation()
+    {
+
+        CRUD::field('title')
+            ->type('section-title')
+            ->title('Add Your Feedback')
+            ->content('Please enter the details below.<br/><br/>
+                    If you are reporting a bug, please tell us what page you were on, what you expected to happen, and what actually happened. If possible, please include a screenshot, as they are very helpful for us to identify the issue.
+                   <br/><br/>
+                   If you are making a suggestion, please let us know what feature or addition you would like to see. We may get in touch with you for more information. Please tell us if you do <span class="font-weight-bold">Not</span> want us to do that below.
+                    ')
+            ->view_namespace('stats4sd.laravel-backpack-section-title::fields');
+
+        CRUD::field('user')->type('hidden')->value(Auth::id());
+
+        CRUD::field('feedbackType')->label('What type of feedback is this?');
+        CRUD::field('text')->type('text')->label('Describe the issue:');
+        CRUD::field('uploads')->type('upload_multiple')->label('If you have screenshots or supporting files, please upload them here.');
+
+
+
+    }
+
+    /**
+     * Define what happens when the Update operation is loaded.
+     *
+     * @see https://backpackforlaravel.com/docs/crud-operation-update
+     * @return void
+     */
+    protected function setupUpdateOperation()
+    {
+        $this->setupCreateOperation();
+    }
+}

--- a/app/Http/Controllers/Admin/UserFeedbackTypeCrudController.php
+++ b/app/Http/Controllers/Admin/UserFeedbackTypeCrudController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Requests\FeedbackTypeRequest;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+/**
+ * Class FeedbackTypeCrudController
+ * @package App\Http\Controllers\Admin
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class UserFeedbackTypeCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+
+    /**
+     * Configure the CrudPanel object. Apply settings to all operations.
+     *
+     * @return void
+     */
+    public function setup()
+    {
+        CRUD::setModel(\App\Models\UserFeedbackType::class);
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/feedback-type');
+        CRUD::setEntityNameStrings('feedback type', 'feedback types');
+    }
+
+    /**
+     * Define what happens when the List operation is loaded.
+     *
+     * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
+     * @return void
+     */
+    protected function setupListOperation()
+    {
+
+
+        /**
+         * Columns can be defined using the fluent syntax or array syntax:
+         * - CRUD::column('price')->type('number');
+         * - CRUD::addColumn(['name' => 'price', 'type' => 'number']);
+         */
+    }
+
+    /**
+     * Define what happens when the Create operation is loaded.
+     *
+     * @see https://backpackforlaravel.com/docs/crud-operation-create
+     * @return void
+     */
+    protected function setupCreateOperation()
+    {
+
+
+        /**
+         * Fields can be defined using the fluent syntax or array syntax:
+         * - CRUD::field('price')->type('number');
+         * - CRUD::addField(['name' => 'price', 'type' => 'number']));
+         */
+    }
+
+    /**
+     * Define what happens when the Update operation is loaded.
+     *
+     * @see https://backpackforlaravel.com/docs/crud-operation-update
+     * @return void
+     */
+    protected function setupUpdateOperation()
+    {
+        $this->setupCreateOperation();
+    }
+}

--- a/app/Http/Controllers/UserFeedbackController.php
+++ b/app/Http/Controllers/UserFeedbackController.php
@@ -3,8 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\UserFeedbackRequest;
+use App\Mail\UserFeedbackSubmitted;
+use App\Models\User;
 use App\Models\UserFeedback;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 
 class UserFeedbackController extends Controller
 {
@@ -16,6 +20,16 @@ class UserFeedbackController extends Controller
 
         $feedback->syncFromMediaLibraryRequest($request->uploads)
             ->toMediaLibrary();
+
+        // send email
+
+        $managers = User::whereHas('roles', function (Builder $query) {
+            $query->whereIn('roles.name', ['Site Admin', 'Site Manager']);
+        })->get();
+
+        foreach ($managers as $manager) {
+            Mail::to($manager->email)->send(new UserFeedbackSubmitted($feedback));
+        }
 
         return $feedback;
     }

--- a/app/Http/Controllers/UserFeedbackController.php
+++ b/app/Http/Controllers/UserFeedbackController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UserFeedbackRequest;
+use App\Models\UserFeedback;
+use Illuminate\Http\Request;
+
+class UserFeedbackController extends Controller
+{
+    public function store(UserFeedbackRequest $request)
+    {
+        $validated = $request->validated();
+
+        $feedback = UserFeedback::create($validated);
+
+        $feedback->syncFromMediaLibraryRequest($request->uploads)
+            ->toMediaLibrary();
+
+        return $feedback;
+    }
+}

--- a/app/Http/Requests/UserFeedbackRequest.php
+++ b/app/Http/Requests/UserFeedbackRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Spatie\MediaLibraryPro\Rules\Concerns\ValidatesMedia;
+
+class UserFeedbackRequest extends FormRequest
+{
+
+    use ValidatesMedia;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'user_id' => 'nullable|exists:users,id',
+            'user_feedback_type_id' => 'required|exists:user_feedback_types,id',
+            'message' => 'required|max:65535',
+            'uploads' => ['sometimes', 'nullable', $this
+                ->validateMultipleMedia()
+                ->maxItems(5)
+                ->maxItemSizeInKb(10000)
+            ],
+        ];
+    }
+}

--- a/app/Mail/UserFeedbackSubmitted.php
+++ b/app/Mail/UserFeedbackSubmitted.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\UserFeedback;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class UserFeedbackSubmitted extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public UserFeedback $feedback)
+    {
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: $this->feedback->type->name . ' Submitted',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.user_feedback_submitted',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -82,7 +82,9 @@ class Organisation extends Model
 
     public function admins()
     {
-        return $this->belongsToMany(User::class, 'organisation_members')->withPivot('role')->wherePivot('role', '=', 'Site Admin');
+        return $this->belongsToMany(User::class, 'organisation_members')->whereHas('roles', function(Builder $query) {
+            $query->where('roles.name', 'Institutional Admin');
+        });
     }
 
     public function editors()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Traits\HasRoles;
@@ -53,6 +54,11 @@ class User extends Authenticatable
         return $this->hasMany(RemovalRequest::class, 'requester_id');
     }
 
+    public function userFeedBacks(): HasMany
+    {
+        return $this->hasMany(UserFeedback::class);
+    }
+
     public function isAdmin()
     {
         return $this->hasAnyRole('Site Admin');
@@ -65,4 +71,5 @@ class User extends Authenticatable
             ->map(fn(Permission $permission): string => $permission->name);
         return $this;
     }
+
 }

--- a/app/Models/UserFeedback.php
+++ b/app/Models/UserFeedback.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
+
+class UserFeedback extends Model
+{
+    use CrudTrait;
+
+    protected $table = 'user_feedbacks';
+    protected $guarded = ['id'];
+
+    protected static function booted()
+    {
+        static::addGlobalScope('owned', function (Builder $builder) {
+
+            // if the current user can maintain users, they can see all feedback.
+            if(Auth::user()->can('maintain users')) {
+                return;
+            }
+
+            // otherwise, they see their own feedback.
+            $builder->where('user_id', Auth::id());
+
+        });
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function feedbackType(): BelongsTo
+    {
+        return $this->belongsTo(UserFeedbackType::class);
+    }
+}

--- a/app/Models/UserFeedback.php
+++ b/app/Models/UserFeedback.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Auth;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
@@ -23,7 +24,7 @@ class UserFeedback extends Model implements HasMedia
         static::addGlobalScope('owned', function (Builder $builder) {
 
             // if the current user can maintain users, they can see all feedback.
-            if(Auth::user()->can('maintain users')) {
+            if(Auth::user()->can('manage user feedback')) {
                 return;
             }
 
@@ -38,8 +39,13 @@ class UserFeedback extends Model implements HasMedia
         return $this->belongsTo(User::class);
     }
 
-    public function feedbackType(): BelongsTo
+    public function type(): BelongsTo
     {
         return $this->belongsTo(UserFeedbackType::class);
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(UserFeedbackComment::class);
     }
 }

--- a/app/Models/UserFeedback.php
+++ b/app/Models/UserFeedback.php
@@ -3,14 +3,17 @@
 namespace App\Models;
 
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Auth;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 
-class UserFeedback extends Model
+class UserFeedback extends Model implements HasMedia
 {
-    use CrudTrait;
+    use CrudTrait, InteractsWithMedia;
 
     protected $table = 'user_feedbacks';
     protected $guarded = ['id'];

--- a/app/Models/UserFeedback.php
+++ b/app/Models/UserFeedback.php
@@ -41,11 +41,11 @@ class UserFeedback extends Model implements HasMedia
 
     public function type(): BelongsTo
     {
-        return $this->belongsTo(UserFeedbackType::class);
+        return $this->belongsTo(UserFeedbackType::class, 'user_feedback_type_id');
     }
 
     public function comments(): HasMany
     {
-        return $this->hasMany(UserFeedbackComment::class);
+        return $this->hasMany(UserFeedbackComment::class, 'user_feedback_id');
     }
 }

--- a/app/Models/UserFeedbackComment.php
+++ b/app/Models/UserFeedbackComment.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserFeedbackComment extends Model
+{
+    use CrudTrait;
+
+    protected $guarded = [];
+    public function userFeedback(): BelongsTo
+    {
+        return $this->belongsTo(UserFeedback::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+
+    }
+
+}

--- a/app/Models/UserFeedbackType.php
+++ b/app/Models/UserFeedbackType.php
@@ -11,7 +11,7 @@ class UserFeedbackType extends Model
 {
     use CrudTrait;
 
-    protected $table = 'feedback_types';
+    protected $table = 'user_feedback_types';
     protected $guarded = ['id'];
 
 

--- a/app/Models/UserFeedbackType.php
+++ b/app/Models/UserFeedbackType.php
@@ -17,6 +17,6 @@ class UserFeedbackType extends Model
 
     public function userFeedbacks(): HasMany
     {
-        return $this->hasMany(UserFeedback::class);
+        return $this->hasMany(UserFeedback::class, 'user_feedback_type_id');
     }
 }

--- a/app/Models/UserFeedbackType.php
+++ b/app/Models/UserFeedbackType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class UserFeedbackType extends Model
+{
+    use CrudTrait;
+
+    protected $table = 'feedback_types';
+    protected $guarded = ['id'];
+
+
+    public function userFeedbacks(): HasMany
+    {
+        return $this->hasMany(UserFeedback::class);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "stats4sd/laravel-template",
     "type": "project",
     "description": "A Laravel Data Platform Template.",
-    "keywords": ["framework", "laravel", "template"],
+    "keywords": [
+        "framework",
+        "laravel",
+        "template"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.1",
@@ -19,6 +23,8 @@
         "maatwebsite/excel": "^3.1",
         "orangehill/iseed": "^3.0",
         "spatie/browsershot": "^3.57",
+        "spatie/laravel-medialibrary": "^10.0.0",
+        "spatie/laravel-medialibrary-pro": "^2.0.0",
         "stats4sd/laravel-backpack-section-title": "dev-backpack-5",
         "stats4sd/laravel-file-util": "dev-laravel-9-support",
         "stats4sd/laravel-sql-views": "^v1.1.0",
@@ -81,6 +87,10 @@
         {
             "type": "composer",
             "url": "https://repo.backpackforlaravel.com/"
+        },
+        {
+            "type": "composer",
+            "url": "https://satis.spatie.be"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e41ff43ed57bb3bc2934779a5bbc0a01",
+    "content-hash": "566087b745cf28d81e8d221a85990304",
     "packages": [
         {
             "name": "backpack/crud",
@@ -4943,6 +4943,196 @@
                 "source": "https://github.com/spatie/image-optimizer/tree/1.6.4"
             },
             "time": "2023-03-10T08:43:19+00:00"
+        },
+        {
+            "name": "spatie/laravel-medialibrary",
+            "version": "10.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-medialibrary.git",
+                "reference": "84f7bb253bc7b9498ff2cd0d74f82e88d299c517"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/84f7bb253bc7b9498ff2cd0d74f82e88d299c517",
+                "reference": "84f7bb253bc7b9498ff2cd0d74f82e88d299c517",
+                "shasum": ""
+            },
+            "require": {
+                "ext-exif": "*",
+                "ext-fileinfo": "*",
+                "ext-json": "*",
+                "illuminate/bus": "^9.18|^10.0",
+                "illuminate/conditionable": "^9.18|^10.0",
+                "illuminate/console": "^9.18|^10.0",
+                "illuminate/database": "^9.18|^10.0",
+                "illuminate/pipeline": "^9.18|^10.0",
+                "illuminate/support": "^9.18|^10.0",
+                "intervention/image": "^2.7",
+                "maennchen/zipstream-php": "^2.0|^3.0",
+                "php": "^8.0",
+                "spatie/image": "^2.2.2",
+                "spatie/temporary-directory": "^2.0",
+                "symfony/console": "^6.0"
+            },
+            "conflict": {
+                "php-ffmpeg/php-ffmpeg": "<0.6.1"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.133.11",
+                "doctrine/dbal": "^2.13",
+                "ext-imagick": "*",
+                "ext-pdo_sqlite": "*",
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": "^7.4",
+                "league/flysystem-aws-s3-v3": "^3.0",
+                "mockery/mockery": "^1.4",
+                "nunomaduro/larastan": "^2.0",
+                "orchestra/testbench": "^7.0|^8.0",
+                "pestphp/pest": "^1.21",
+                "phpstan/extension-installer": "^1.1",
+                "spatie/laravel-ray": "^1.28",
+                "spatie/pdf-to-image": "^2.1",
+                "spatie/phpunit-snapshot-assertions": "^4.2"
+            },
+            "suggest": {
+                "league/flysystem-aws-s3-v3": "Required to use AWS S3 file storage",
+                "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails",
+                "spatie/pdf-to-image": "Required for generating thumbnails of PDFs and SVGs"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\MediaLibrary\\MediaLibraryServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\MediaLibrary\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Associate files with Eloquent models",
+            "homepage": "https://github.com/spatie/laravel-medialibrary",
+            "keywords": [
+                "cms",
+                "conversion",
+                "downloads",
+                "images",
+                "laravel",
+                "laravel-medialibrary",
+                "media",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-medialibrary/issues",
+                "source": "https://github.com/spatie/laravel-medialibrary/tree/10.10.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-06-29T07:18:20+00:00"
+        },
+        {
+            "name": "spatie/laravel-medialibrary-pro",
+            "version": "2.7.3",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:spatie/laravel-medialibrary-pro.git",
+                "reference": "3fdd81a942e7068446a4bc82ab8d71300ca78081"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://satis.spatie.be/dist/spatie/laravel-medialibrary-pro/spatie-laravel-medialibrary-pro-3fdd81a942e7068446a4bc82ab8d71300ca78081-zip-7273b3.zip",
+                "reference": "3fdd81a942e7068446a4bc82ab8d71300ca78081",
+                "shasum": "d3955df1e834171fec2ac69cb1e3989a7a147b64"
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/validation": "^9.0|^10.0",
+                "php": "^8.0",
+                "spatie/laravel-medialibrary": "^10.2",
+                "symfony/mime": "^6.0"
+            },
+            "require-dev": {
+                "illuminate/support": "^9.0|^10.0",
+                "livewire/livewire": "^2.10",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^7.0|^8.0",
+                "pestphp/pest": "^1.20",
+                "symfony/var-dumper": "^6.0"
+            },
+            "suggest": {
+                "livewire/livewire": "Allow uploads without using a front end framework"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\MediaLibraryPro\\MediaLibraryProServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\MediaLibraryPro\\": "src"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Spatie\\MediaLibraryPro\\Tests\\": "tests"
+                }
+            },
+            "scripts": {
+                "format": [
+                    "vendor/bin/php-cs-fixer fix --allow-risky=yes"
+                ],
+                "test": [
+                    "vendor/bin/pest"
+                ],
+                "test-coverage": [
+                    "vendor/bin/phpunit --coverage-html coverage"
+                ]
+            },
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Handle media in a Laravel app",
+            "homepage": "https://github.com/spatie/laravel-medialibrary-pro",
+            "keywords": [
+                "laravel-medialibrary-pro",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/laravel-medialibrary-pro/tree/2.7.3",
+                "issues": "https://github.com/spatie/laravel-medialibrary-pro/issues"
+            },
+            "time": "2023-05-19T10:55:42+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -11933,6 +12123,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "everapi/freecurrencyapi-php": 20,
         "stats4sd/laravel-backpack-section-title": 20,
         "stats4sd/laravel-file-util": 20
     },

--- a/config/backpack/base.php
+++ b/config/backpack/base.php
@@ -204,7 +204,7 @@ return array(
 
     // Set this to false if you would like to skip adding "my account" routes
     // (you then need to manually define the routes in your web.php)
-    'setup_my_account_routes' => true,
+    'setup_my_account_routes' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -1,0 +1,237 @@
+<?php
+
+return [
+
+    /*
+     * The disk on which to store added files and derived images by default. Choose
+     * one or more of the disks you've configured in config/filesystems.php.
+     */
+    'disk_name' => env('MEDIA_DISK', 'local'),
+
+    /*
+     * The maximum file size of an item in bytes.
+     * Adding a larger file will result in an exception.
+     */
+    'max_file_size' => 1024 * 1024 * 10, // 10MB
+
+    /*
+     * This queue connection will be used to generate derived and responsive images.
+     * Leave empty to use the default queue connection.
+     */
+    'queue_connection_name' => env('QUEUE_CONNECTION', 'sync'),
+
+    /*
+     * This queue will be used to generate derived and responsive images.
+     * Leave empty to use the default queue.
+     */
+    'queue_name' => '',
+
+    /*
+     * By default all conversions will be performed on a queue.
+     */
+    'queue_conversions_by_default' => env('QUEUE_CONVERSIONS_BY_DEFAULT', true),
+
+    /*
+     * The fully qualified class name of the media model.
+     */
+    'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
+
+    /*
+     * The fully qualified class name of the model used for temporary uploads.
+     *
+     * This model is only used in Media Library Pro (https://medialibrary.pro)
+     */
+    'temporary_upload_model' => Spatie\MediaLibraryPro\Models\TemporaryUpload::class,
+
+    /*
+     * When enabled, Media Library Pro will only process temporary uploads that were uploaded
+     * in the same session. You can opt to disable this for stateless usage of
+     * the pro components.
+     */
+    'enable_temporary_uploads_session_affinity' => true,
+
+    /*
+     * When enabled, Media Library pro will generate thumbnails for uploaded file.
+     */
+    'generate_thumbnails_for_temporary_uploads' => true,
+
+    /*
+     * This is the class that is responsible for naming generated files.
+     */
+    'file_namer' => Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class,
+
+    /*
+     * The class that contains the strategy for determining a media file's path.
+     */
+    'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
+
+    /*
+     * Here you can specify which path generator should be used for the given class.
+     */
+    'custom_path_generators' => [
+        // Model::class => PathGenerator::class
+        // or
+        // 'model_morph_alias' => PathGenerator::class
+    ],
+
+    /*
+     * When urls to files get generated, this class will be called. Use the default
+     * if your files are stored locally above the site root or on s3.
+     */
+    'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
+
+    /*
+     * Moves media on updating to keep path consistent. Enable it only with a custom
+     * PathGenerator that uses, for example, the media UUID.
+     */
+    'moves_media_on_update' => false,
+
+    /*
+     * Whether to activate versioning when urls to files get generated.
+     * When activated, this attaches a ?v=xx query string to the URL.
+     */
+    'version_urls' => false,
+
+    /*
+     * The media library will try to optimize all converted images by removing
+     * metadata and applying a little bit of compression. These are
+     * the optimizers that will be used by default.
+     */
+    'image_optimizers' => [
+        Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
+            '-m85', // set maximum quality to 85%
+            '--force', // ensure that progressive generation is always done also if a little bigger
+            '--strip-all', // this strips out all text information such as comments and EXIF data
+            '--all-progressive', // this will make sure the resulting image is a progressive one
+        ],
+        Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
+            '--force', // required parameter for this package
+        ],
+        Spatie\ImageOptimizer\Optimizers\Optipng::class => [
+            '-i0', // this will result in a non-interlaced, progressive scanned image
+            '-o2', // this set the optimization level to two (multiple IDAT compression trials)
+            '-quiet', // required parameter for this package
+        ],
+        Spatie\ImageOptimizer\Optimizers\Svgo::class => [
+            '--disable=cleanupIDs', // disabling because it is known to cause troubles
+        ],
+        Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
+            '-b', // required parameter for this package
+            '-O3', // this produces the slowest but best results
+        ],
+        Spatie\ImageOptimizer\Optimizers\Cwebp::class => [
+            '-m 6', // for the slowest compression method in order to get the best compression.
+            '-pass 10', // for maximizing the amount of analysis pass.
+            '-mt', // multithreading for some speed improvements.
+            '-q 90', //quality factor that brings the least noticeable changes.
+        ],
+    ],
+
+    /*
+     * These generators will be used to create an image of media files.
+     */
+    'image_generators' => [
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
+    ],
+
+    /*
+     * The path where to store temporary files while performing image conversions.
+     * If set to null, storage_path('media-library/temp') will be used.
+     */
+    'temporary_directory_path' => null,
+
+    /*
+     * The engine that should perform the image conversions.
+     * Should be either `gd` or `imagick`.
+     */
+    'image_driver' => env('IMAGE_DRIVER', 'gd'),
+
+    /*
+     * FFMPEG & FFProbe binaries paths, only used if you try to generate video
+     * thumbnails and have installed the php-ffmpeg/php-ffmpeg composer
+     * dependency.
+     */
+    'ffmpeg_path' => env('FFMPEG_PATH', '/usr/bin/ffmpeg'),
+    'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
+
+    /*
+     * Here you can override the class names of the jobs used by this package. Make sure
+     * your custom jobs extend the ones provided by the package.
+     */
+    'jobs' => [
+        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
+        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+    ],
+
+    /*
+     * When using the addMediaFromUrl method you may want to replace the default downloader.
+     * This is particularly useful when the url of the image is behind a firewall and
+     * need to add additional flags, possibly using curl.
+     */
+    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+
+    'remote' => [
+        /*
+         * Any extra headers that should be included when uploading media to
+         * a remote disk. Even though supported headers may vary between
+         * different drivers, a sensible default has been provided.
+         *
+         * Supported by S3: CacheControl, Expires, StorageClass,
+         * ServerSideEncryption, Metadata, ACL, ContentEncoding
+         */
+        'extra_headers' => [
+            'CacheControl' => 'max-age=604800',
+        ],
+    ],
+
+    'responsive_images' => [
+        /*
+         * This class is responsible for calculating the target widths of the responsive
+         * images. By default we optimize for filesize and create variations that each are 30%
+         * smaller than the previous one. More info in the documentation.
+         *
+         * https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/generating-responsive-images
+         */
+        'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
+
+        /*
+         * By default rendering media to a responsive image will add some javascript and a tiny placeholder.
+         * This ensures that the browser can already determine the correct layout.
+         */
+        'use_tiny_placeholders' => true,
+
+        /*
+         * This class will generate the tiny placeholder used for progressive image loading. By default
+         * the media library will use a tiny blurred jpg image.
+         */
+        'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
+    ],
+
+    /*
+     * When enabling this option, a route will be registered that will enable
+     * the Media Library Pro Vue and React components to move uploaded files
+     * in a S3 bucket to their right place.
+     */
+    'enable_vapor_uploads' => env('ENABLE_MEDIA_LIBRARY_VAPOR_UPLOADS', false),
+
+    /*
+     * When converting Media instances to response the media library will add
+     * a `loading` attribute to the `img` tag. Here you can set the default
+     * value of that attribute.
+     *
+     * Possible values: 'lazy', 'eager', 'auto' or null if you don't want to set any loading instruction.
+     *
+     * More info: https://css-tricks.com/native-lazy-loading/
+     */
+    'default_loading_attribute_value' => null,
+
+    /*
+     * You can specify a prefix for that is used for storing all media.
+     * If you set this to `/my-subdir`, all your media will be stored in a `/my-subdir` directory.
+     */
+    'prefix' => env('MEDIA_PREFIX', ''),
+];

--- a/database/migrations/2023_07_19_104812_create_user_feedback_types_table.php
+++ b/database/migrations/2023_07_19_104812_create_user_feedback_types_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_feedback_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_feedback_types');
+    }
+};

--- a/database/migrations/2023_07_19_111735_create_user_feedback_table.php
+++ b/database/migrations/2023_07_19_111735_create_user_feedback_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_feedback', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users')->cascadeOnUpdate()->nullOnDelete();
+            $table->foreignId('user_feedback_type_id')->nullable()->constrained('user_feedback_types')->cascadeOnUpdate()->nullOnDelete();
+            $table->text('message');
+            $table->text('attachments');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_feedback');
+    }
+};

--- a/database/migrations/2023_07_19_111735_create_user_feedback_table.php
+++ b/database/migrations/2023_07_19_111735_create_user_feedback_table.php
@@ -11,12 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('user_feedback', function (Blueprint $table) {
+        Schema::create('user_feedbacks', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->nullable()->constrained('users')->cascadeOnUpdate()->nullOnDelete();
             $table->foreignId('user_feedback_type_id')->nullable()->constrained('user_feedback_types')->cascadeOnUpdate()->nullOnDelete();
             $table->text('message');
-            $table->text('attachments');
+            $table->text('attachments')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_07_20_115603_create_temporary_uploads_table.php
+++ b/database/migrations/2023_07_20_115603_create_temporary_uploads_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('temporary_uploads', function (Blueprint $table) {
+            $table->id();
+            $table->string('session_id');
+            $table->timestamps();
+        });
+    }
+};

--- a/database/migrations/2023_07_20_115625_create_media_table.php
+++ b/database/migrations/2023_07_20_115625_create_media_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+
+            $table->morphs('model');
+            $table->uuid('uuid')->nullable()->unique();
+            $table->string('collection_name');
+            $table->string('name');
+            $table->string('file_name');
+            $table->string('mime_type')->nullable();
+            $table->string('disk');
+            $table->string('conversions_disk')->nullable();
+            $table->unsignedBigInteger('size');
+            $table->json('manipulations');
+            $table->json('custom_properties');
+            $table->json('generated_conversions');
+            $table->json('responsive_images');
+            $table->unsignedInteger('order_column')->nullable()->index();
+
+            $table->nullableTimestamps();
+        });
+    }
+};

--- a/database/migrations/2023_07_20_151531_create_user_feedback_comments_table.php
+++ b/database/migrations/2023_07_20_151531_create_user_feedback_comments_table.php
@@ -11,10 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('user_feedbacks', function (Blueprint $table) {
+        Schema::create('user_feedback_comments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->nullable()->constrained('users')->cascadeOnUpdate()->nullOnDelete();
-            $table->foreignId('user_feedback_type_id')->nullable()->constrained('user_feedback_types')->cascadeOnUpdate()->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete()->cascadeOnUpdate();
+            $table->foreignId('user_feedback_id')->constrained('user_feedbacks')->cascadeOnUpdate()->cascadeOnDelete();
             $table->text('message');
             $table->timestamps();
         });
@@ -25,6 +25,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('user_feedback');
+        Schema::dropIfExists('user_feedback_comments');
     }
 };

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,7 @@ class DatabaseSeeder extends Seeder
         $this->call(PrinciplesTableSeeder::class);
         $this->call(InitiativeCategorySeeder::class);
         $this->call(InstitutionTypeSeeder::class);
+        $this->call(UserFeedbackTypeSeeder::class);
         $this->call(TestSeeder::class);
         $this->call(DashboardRatingSeeder::class);
         $this->call(ProjectSeeder::class);

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -17,198 +17,189 @@ class RoleSeeder extends Seeder
     public function run()
     {
         // roles
-        $siteAdmin = Role::updateOrCreate(
-            ['name' => 'admin', 'guard_name' => 'web'],
-            ['name' => 'Site Admin', 'guard_name' => 'web']
-        );
-
-        Role::create(['name' => 'Site Manager', 'guard_name' => 'web']);
-        Role::create(['name' => 'Institutional Admin', 'guard_name' => 'web']);
-        Role::create(['name' => 'Institutional Assessor', 'guard_name' => 'web']);
-        Role::create(['name' => 'Institutional Member', 'guard_name' => 'web']);
+        $admin = Role::updateOrCreate(['name' => 'Site Admin', 'guard_name' => 'web']);
+        $manager = Role::updateOrCreate(['name' => 'Site Manager', 'guard_name' => 'web']);
+        $insAdmin = Role::updateOrCreate(['name' => 'Institutional Admin', 'guard_name' => 'web']);
+        $insAssessor = Role::updateOrCreate(['name' => 'Institutional Assessor', 'guard_name' => 'web']);
+        $insMember = Role::updateOrCreate(['name' => 'Institutional Member', 'guard_name' => 'web']);
 
 
         // permissions
-        Permission::create(['name' => 'view continents', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view regions', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view countries', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view users', 'guard_name' => 'web']);
-        Permission::create(['name' => 'maintain users', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view continents', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view regions', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view countries', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view users', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain users', 'guard_name' => 'web']);
 
-        Permission::create(['name' => 'view admin user invites', 'guard_name' => 'web']);
-        Permission::create(['name' => 'maintain admin user invites', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view red lines', 'guard_name' => 'web']);
-        Permission::create(['name' => 'maintain red lines', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view principles', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view admin user invites', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain admin user invites', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view red lines', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain red lines', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view principles', 'guard_name' => 'web']);
 
-        Permission::create(['name' => 'maintain principles', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view score tags', 'guard_name' => 'web']);
-        Permission::create(['name' => 'maintain score tags', 'guard_name' => 'web']);
-        Permission::create(['name' => 'review custom score tags', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view institutions', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain principles', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view score tags', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain score tags', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'review custom score tags', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view institutions', 'guard_name' => 'web']);
 
-        Permission::create(['name' => 'maintain institutions', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view institutional members', 'guard_name' => 'web']);
-        Permission::create(['name' => 'invite institutional members', 'guard_name' => 'web']);
-        Permission::create(['name' => 'maintain institutional members', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view institution-level dashboard', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain institutions', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view institutional members', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'invite institutional members', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain institutional members', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view institution-level dashboard', 'guard_name' => 'web']);
 
-        Permission::create(['name' => 'view portfolio-level dashboard', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view project-level dashboard', 'guard_name' => 'web']);
-        Permission::create(['name' => 'download institution-level data', 'guard_name' => 'web']);
-        Permission::create(['name' => 'download portfolio-level data', 'guard_name' => 'web']);
-        Permission::create(['name' => 'download project-level data', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view portfolio-level dashboard', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view project-level dashboard', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'download institution-level data', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'download portfolio-level data', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'download project-level data', 'guard_name' => 'web']);
 
-        Permission::create(['name' => 'download dashboard summary data', 'guard_name' => 'web']);
-        // Permission::create(['name' => 'create new custom score tags', 'guard_name' => 'web']);
-        Permission::create(['name' => 'request to remove everything for institution', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view portfolios', 'guard_name' => 'web']);
-        Permission::create(['name' => 'maintain portfolios', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view projects', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'download dashboard summary data', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'request to remove everything for institution', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view portfolios', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain portfolios', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view projects', 'guard_name' => 'web']);
 
-        Permission::create(['name' => 'maintain projects', 'guard_name' => 'web']);
-        Permission::create(['name' => 'review redlines', 'guard_name' => 'web']);
-        Permission::create(['name' => 'assess project', 'guard_name' => 'web']);
-        Permission::create(['name' => 'show institution name and role', 'guard_name' => 'web']);
-        Permission::create(['name' => 'request to remove all personal data from an institution', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain projects', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'review redlines', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'assess project', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'show institution name and role', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'request to remove all personal data from an institution', 'guard_name' => 'web']);
 
-        Permission::create(['name' => 'request to leave an institution', 'guard_name' => 'web']);
-        Permission::create(['name' => 'select institution', 'guard_name' => 'web']);
-        Permission::create(['name' => 'auto set default institution', 'guard_name' => 'web']);
-        Permission::create(['name' => 'view custom principles', 'guard_name' => 'web']);
-        Permission::create(['name' => 'maintain custom principles', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'request to leave an institution', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'select institution', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'auto set default institution', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'view custom principles', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'maintain custom principles', 'guard_name' => 'web']);
 
         // extras
-        Permission::create(['name' => 'edit own institution', 'guard_name' => 'web']);
-
-
+        Permission::updateOrCreate(['name' => 'edit own institution', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'manage user feedback', 'guard_name' => 'web']);
 
 
         // roles_has_permissions
         DB::table('role_has_permissions')->delete();
 
-        // site admin
-        DB::table('role_has_permissions')->insert([
-            [ 'role_id' => 1, 'permission_id' => 1, ],
-            [ 'role_id' => 1, 'permission_id' => 2, ],
-            [ 'role_id' => 1, 'permission_id' => 3, ],
-            [ 'role_id' => 1, 'permission_id' => 4, ],
-            [ 'role_id' => 1, 'permission_id' => 5, ],
-            [ 'role_id' => 1, 'permission_id' => 6, ],
-            [ 'role_id' => 1, 'permission_id' => 7, ],
-            [ 'role_id' => 1, 'permission_id' => 8, ],
-            [ 'role_id' => 1, 'permission_id' => 9, ],
-            [ 'role_id' => 1, 'permission_id' => 10, ],
-            [ 'role_id' => 1, 'permission_id' => 11, ],
-            [ 'role_id' => 1, 'permission_id' => 12, ],
-            [ 'role_id' => 1, 'permission_id' => 13, ],
-            [ 'role_id' => 1, 'permission_id' => 14, ],
-            [ 'role_id' => 1, 'permission_id' => 15, ],
-            [ 'role_id' => 1, 'permission_id' => 16, ],
-            [ 'role_id' => 1, 'permission_id' => 17, ],
-            [ 'role_id' => 1, 'permission_id' => 18, ],
-            [ 'role_id' => 1, 'permission_id' => 19, ],
-            [ 'role_id' => 1, 'permission_id' => 20, ],
-            [ 'role_id' => 1, 'permission_id' => 21, ],
-            [ 'role_id' => 1, 'permission_id' => 22, ],
-            [ 'role_id' => 1, 'permission_id' => 23, ],
-            [ 'role_id' => 1, 'permission_id' => 24, ],
-            [ 'role_id' => 1, 'permission_id' => 25, ],
-            [ 'role_id' => 1, 'permission_id' => 26, ],
-            // [ 'role_id' => 1, 'permission_id' => 27, ],
-            [ 'role_id' => 1, 'permission_id' => 27, ],
-            [ 'role_id' => 1, 'permission_id' => 28, ],
-            [ 'role_id' => 1, 'permission_id' => 29, ],
-            [ 'role_id' => 1, 'permission_id' => 30, ],
-            [ 'role_id' => 1, 'permission_id' => 31, ],
-            [ 'role_id' => 1, 'permission_id' => 32, ],
-            [ 'role_id' => 1, 'permission_id' => 33, ],
-            [ 'role_id' => 1, 'permission_id' => 37, ],
-            [ 'role_id' => 1, 'permission_id' => 39, ],
-            [ 'role_id' => 1, 'permission_id' => 40, ],
-        ]);
+        $admin->givePermissionTo('view continents');
+        $admin->givePermissionTo('view regions');
+        $admin->givePermissionTo('view countries');
+        $admin->givePermissionTo('view users');
+        $admin->givePermissionTo('maintain users');
 
-        // site manager
-        DB::table('role_has_permissions')->insert([
-            [ 'role_id' => 2, 'permission_id' => 8, ],
-            [ 'role_id' => 2, 'permission_id' => 9, ],
-            [ 'role_id' => 2, 'permission_id' => 10, ],
-            [ 'role_id' => 2, 'permission_id' => 11, ],
-            [ 'role_id' => 2, 'permission_id' => 12, ],
-            [ 'role_id' => 2, 'permission_id' => 13, ],
-            [ 'role_id' => 2, 'permission_id' => 14, ],
-            [ 'role_id' => 2, 'permission_id' => 15, ],
-            [ 'role_id' => 2, 'permission_id' => 16, ],
-            [ 'role_id' => 2, 'permission_id' => 17, ],
-            [ 'role_id' => 2, 'permission_id' => 37, ],
-            [ 'role_id' => 2, 'permission_id' => 39, ],
-            [ 'role_id' => 2, 'permission_id' => 40, ],
-        ]);
+        $admin->givePermissionTo('view admin user invites');
+        $admin->givePermissionTo('maintain admin user invites');
+        $admin->givePermissionTo('view red lines');
+        $admin->givePermissionTo('maintain red lines');
+        $admin->givePermissionTo('view principles');
 
-        // institutional admin
-        DB::table('role_has_permissions')->insert([
-            [ 'role_id' => 3, 'permission_id' => 17, ],
-            [ 'role_id' => 3, 'permission_id' => 18, ],
-            [ 'role_id' => 3, 'permission_id' => 19, ],
-            [ 'role_id' => 3, 'permission_id' => 20, ],
-            [ 'role_id' => 3, 'permission_id' => 21, ],
-            [ 'role_id' => 3, 'permission_id' => 22, ],
-            [ 'role_id' => 3, 'permission_id' => 23, ],
-            [ 'role_id' => 3, 'permission_id' => 24, ],
-            [ 'role_id' => 3, 'permission_id' => 25, ],
-            [ 'role_id' => 3, 'permission_id' => 26, ],
-            // [ 'role_id' => 3, 'permission_id' => 27, ],
-            [ 'role_id' => 3, 'permission_id' => 27, ],
-            [ 'role_id' => 3, 'permission_id' => 28, ],
-            [ 'role_id' => 3, 'permission_id' => 29, ],
-            [ 'role_id' => 3, 'permission_id' => 30, ],
-            [ 'role_id' => 3, 'permission_id' => 31, ],
-            [ 'role_id' => 3, 'permission_id' => 32, ],
-            [ 'role_id' => 3, 'permission_id' => 33, ],
-            [ 'role_id' => 3, 'permission_id' => 34, ],
-            [ 'role_id' => 3, 'permission_id' => 35, ],
-            [ 'role_id' => 3, 'permission_id' => 36, ],
-            [ 'role_id' => 3, 'permission_id' => 38, ],
-            [ 'role_id' => 3, 'permission_id' => 39, ],
-            [ 'role_id' => 3, 'permission_id' => 40, ],
-            [ 'role_id' => 3, 'permission_id' => 41, ],
-        ]);
+        $admin->givePermissionTo('maintain principles');
+        $admin->givePermissionTo('view score tags');
+        $admin->givePermissionTo('maintain score tags');
+        $admin->givePermissionTo('review custom score tags');
+        $admin->givePermissionTo('view institutions');
 
-        // institutional assessor
-        DB::table('role_has_permissions')->insert([
-            [ 'role_id' => 4, 'permission_id' => 20, ],
-            [ 'role_id' => 4, 'permission_id' => 21, ],
-            [ 'role_id' => 4, 'permission_id' => 22, ],
-            [ 'role_id' => 4, 'permission_id' => 26, ],
-            // [ 'role_id' => 4, 'permission_id' => 27, ],
-            [ 'role_id' => 4, 'permission_id' => 27, ],
-            [ 'role_id' => 4, 'permission_id' => 28, ],
-            [ 'role_id' => 4, 'permission_id' => 29, ],
-            [ 'role_id' => 4, 'permission_id' => 30, ],
-            [ 'role_id' => 4, 'permission_id' => 31, ],
-            [ 'role_id' => 4, 'permission_id' => 32, ],
-            [ 'role_id' => 4, 'permission_id' => 33, ],
-            [ 'role_id' => 4, 'permission_id' => 34, ],
-            [ 'role_id' => 4, 'permission_id' => 35, ],
-            [ 'role_id' => 4, 'permission_id' => 36, ],
-            [ 'role_id' => 4, 'permission_id' => 38, ],
-            [ 'role_id' => 4, 'permission_id' => 39, ],
-            [ 'role_id' => 4, 'permission_id' => 40, ],
-        ]);
+        $admin->givePermissionTo('maintain institutions');
+        $admin->givePermissionTo('view institutional members');
+        $admin->givePermissionTo('invite institutional members');
+        $admin->givePermissionTo('maintain institutional members');
+        $admin->givePermissionTo('view institution-level dashboard');
 
-        // institutional member
-        DB::table('role_has_permissions')->insert([
-            [ 'role_id' => 5, 'permission_id' => 20, ],
-            [ 'role_id' => 5, 'permission_id' => 21, ],
-            [ 'role_id' => 5, 'permission_id' => 22, ],
-            [ 'role_id' => 5, 'permission_id' => 26, ],
-            [ 'role_id' => 5, 'permission_id' => 34, ],
-            [ 'role_id' => 5, 'permission_id' => 35, ],
-            [ 'role_id' => 5, 'permission_id' => 36, ],
-            [ 'role_id' => 5, 'permission_id' => 38, ],
-            [ 'role_id' => 5, 'permission_id' => 39, ],
-            [ 'role_id' => 5, 'permission_id' => 40, ],
-        ]);
+        $admin->givePermissionTo('view portfolio-level dashboard');
+        $admin->givePermissionTo('view project-level dashboard');
+        $admin->givePermissionTo('download institution-level data');
+        $admin->givePermissionTo('download portfolio-level data');
+        $admin->givePermissionTo('download project-level data');
+
+        $admin->givePermissionTo('download dashboard summary data');
+        $admin->givePermissionTo('request to remove everything for institution');
+        $admin->givePermissionTo('view portfolios');
+        $admin->givePermissionTo('maintain portfolios');
+        $admin->givePermissionTo('view projects');
+
+        $admin->givePermissionTo('maintain projects');
+        $admin->givePermissionTo('review redlines');
+        $admin->givePermissionTo('assess project');
+
+        $admin->givePermissionTo('select institution');
+        $admin->givePermissionTo('view custom principles');
+        $admin->givePermissionTo('maintain custom principles');
+
+        $admin->givePermissionTo('manage user feedback');
+
+
+        $manager->givePermissionTo('view red lines');
+        $manager->givePermissionTo('maintain red lines');
+        $manager->givePermissionTo('view principles');
+        $manager->givePermissionTo('maintain principles');
+        $manager->givePermissionTo('view score tags');
+        $manager->givePermissionTo('maintain score tags');
+        $manager->givePermissionTo('review custom score tags');
+        $manager->givePermissionTo('view institutions');
+        $manager->givePermissionTo('maintain institutions');
+        $manager->givePermissionTo('view institutional members');
+        $manager->givePermissionTo('select institution');
+        $manager->givePermissionTo('view custom principles');
+        $manager->givePermissionTo('maintain custom principles');
+        $manager->givePermissionTo('view institutional members');
+        $manager->givePermissionTo('manage user feedback');
+
+
+        $insAdmin->givePermissionTo('invite institutional members');
+        $insAdmin->givePermissionTo('maintain institutional members');
+        $insAdmin->givePermissionTo('view institution-level dashboard');
+        $insAdmin->givePermissionTo('view portfolio-level dashboard');
+        $insAdmin->givePermissionTo('view project-level dashboard');
+        $insAdmin->givePermissionTo('download institution-level data');
+        $insAdmin->givePermissionTo('download portfolio-level data');
+        $insAdmin->givePermissionTo('download project-level data');
+        $insAdmin->givePermissionTo('download dashboard summary data');
+        $insAdmin->givePermissionTo('request to remove everything for institution');
+
+        $insAdmin->givePermissionTo('view portfolios');
+        $insAdmin->givePermissionTo('maintain portfolios');
+        $insAdmin->givePermissionTo('view projects');
+        $insAdmin->givePermissionTo('maintain projects');
+        $insAdmin->givePermissionTo('review redlines');
+        $insAdmin->givePermissionTo('assess project');
+        $insAdmin->givePermissionTo('show institution name and role');
+        $insAdmin->givePermissionTo('request to remove all personal data from an institution');
+        $insAdmin->givePermissionTo('request to leave an institution');
+        $insAdmin->givePermissionTo('auto set default institution');
+
+        $insAdmin->givePermissionTo('view custom principles');
+        $insAdmin->givePermissionTo('maintain custom principles');
+        $insAdmin->givePermissionTo('edit own institution');
+
+
+        $insAssessor->givePermissionTo('view institution-level dashboard');
+        $insAssessor->givePermissionTo('view portfolio-level dashboard');
+        $insAssessor->givePermissionTo('view project-level dashboard');
+        $insAssessor->givePermissionTo('download dashboard summary data');
+        $insAssessor->givePermissionTo('view portfolios');
+        $insAssessor->givePermissionTo('maintain portfolios');
+        $insAssessor->givePermissionTo('view projects');
+        $insAssessor->givePermissionTo('maintain projects');
+        $insAssessor->givePermissionTo('review redlines');
+        $insAssessor->givePermissionTo('assess project');
+        $insAssessor->givePermissionTo('show institution name and role');
+        $insAssessor->givePermissionTo('request to remove all personal data from an institution');
+        $insAssessor->givePermissionTo('request to leave an institution');
+        $insAssessor->givePermissionTo('auto set default institution');
+        $insAssessor->givePermissionTo('view custom principles');
+        $insAssessor->givePermissionTo('maintain custom principles');
+
+
+        $insMember->givePermissionTo('view institution-level dashboard');
+        $insMember->givePermissionTo('view portfolio-level dashboard');
+        $insMember->givePermissionTo('view project-level dashboard');
+        $insMember->givePermissionTo('download dashboard summary data');
+        $insMember->givePermissionTo('show institution name and role');
+        $insMember->givePermissionTo('request to remove all personal data from an institution');
+        $insMember->givePermissionTo('request to leave an institution');
+        $insMember->givePermissionTo('auto set default institution');
+        $insMember->givePermissionTo('view custom principles');
+        $insMember->givePermissionTo('maintain custom principles');
 
     }
 }

--- a/database/seeders/UserFeedbackTypeSeeder.php
+++ b/database/seeders/UserFeedbackTypeSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\UserFeedbackType;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class UserFeedbackTypeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        UserFeedbackType::create(['name' => 'Bug']);
+        UserFeedbackType::create(['name' => 'Feature Request']);
+        UserFeedbackType::create(['name' => 'General Feedback']);
+    }
+}

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -6,155 +6,155 @@
     </div>
 
     <div class="card-body">
-            <div class="form-group row mt-16">
-                <label for="input_name" class="col-sm-4 col-form-label text-right pr-2">Institution Name</label>
-                <div class="col-sm-8">
-                    <input name="name"
-                           class="form-control"
-                           id="input_name"
-                           v-model="institution.name"
-                           :disabled="!canEdit"
-                    >
-                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('name')">
+        <div class="form-group row mt-16">
+            <label for="input_name" class="col-sm-4 col-form-label text-right pr-2">Institution Name</label>
+            <div class="col-sm-8">
+                <input name="name"
+                       class="form-control"
+                       id="input_name"
+                       v-model="institution.name"
+                       :disabled="!canEdit"
+                >
+                <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('name')">
                             <strong v-for="error in errors.name">{{ error }}</strong><br/>
                         </span>
-                </div>
             </div>
+        </div>
 
-            <div class="form-group row">
-                <label for="input_currency" class="col-sm-4 col-form-label text-right pr-2">Main Currency (3-letter
-                    code)</label>
-                <div class="col-sm-8 col-lg-4">
-                    <input
-                        name="currency"
-                        class="form-control"
-                        id="input_currency"
-                        v-model="institution.currency"
-                        :disabled="!canEdit"
+        <div class="form-group row">
+            <label for="input_currency" class="col-sm-4 col-form-label text-right pr-2">Main Currency (3-letter
+                code)</label>
+            <div class="col-sm-8 col-lg-4">
+                <input
+                    name="currency"
+                    class="form-control"
+                    id="input_currency"
+                    v-model="institution.currency"
+                    :disabled="!canEdit"
 
-                    >
-                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('currency')">
+                >
+                <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('currency')">
                             <strong v-for="error in errors.currency">{{ error }}</strong><br/>
                         </span>
-                    <small id="currencyHelp" class="form-text font-sm">This currency will be used for the summary
-                        dashboard. All initiative budgets for your institution will be converted into this
-                        currency.</small>
-                </div>
+                <small id="currencyHelp" class="form-text font-sm">This currency will be used for the summary
+                    dashboard. All initiative budgets for your institution will be converted into this
+                    currency.</small>
             </div>
-            <div class="form-group row">
-                <div class="col-sm-8 offset-sm-4">
-                    <div class="form-check">
-                        <input
-                            class="form-check-input"
-                            type="checkbox"
-                            id="additional_criteria_check"
-                            name="has_additional_criteria"
-                            v-model="institution.has_additional_criteria"
-                            :value="1"
-                            :disabled="!canEdit"
-                        >
-                        <label class="form-check-label" for="additional_criteria_check">
-                            This Institution uses additional assessment criteria
-                        </label>
-                        <span class="text-danger emphasis show" role="alert"
-                              v-if="errors.hasOwnProperty('has_additional_criteria')">
+        </div>
+        <div class="form-group row">
+            <div class="col-sm-8 offset-sm-4">
+                <div class="form-check">
+                    <input
+                        class="form-check-input"
+                        type="checkbox"
+                        id="additional_criteria_check"
+                        name="has_additional_criteria"
+                        v-model="institution.has_additional_criteria"
+                        :value="1"
+                        :disabled="!canEdit"
+                    >
+                    <label class="form-check-label" for="additional_criteria_check">
+                        This Institution uses additional assessment criteria
+                    </label>
+                    <span class="text-danger emphasis show" role="alert"
+                          v-if="errors.hasOwnProperty('has_additional_criteria')">
                             <strong v-for="error in errors.has_additional_criteria">{{ error }}</strong><br/>
                         </span>
-                    </div>
                 </div>
             </div>
-            <hr/>
-            <div class="form-group row">
-                <div class="col-sm-4">
-                    <h3>Optional Information</h3>
-                    <p>Adding additional information will help improve the analysis of anonymised results.</p>
-                </div>
+        </div>
+        <hr/>
+        <div class="form-group row">
+            <div class="col-sm-4">
+                <h3>Optional Information</h3>
+                <p>Adding additional information will help improve the analysis of anonymised results.</p>
             </div>
-            <hr/>
+        </div>
+        <hr/>
 
-            <div class="form-group row">
-                <label for="input_type" class="col-sm-4 col-form-label text-right pr-2">Select the Institution
-                    Type</label>
-                <div class="col-sm-8 col-lg-4">
-                    <v-select
-                        name="institution_type"
-                        id="input_type"
-                        v-model="institution.institution_type_id"
-                        :options="institutionTypes"
-                        label="name"
-                        :reduce="institutionType => institutionType.id"
-                        :disabled="!canEdit"
+        <div class="form-group row">
+            <label for="input_type" class="col-sm-4 col-form-label text-right pr-2">Select the Institution
+                Type</label>
+            <div class="col-sm-8 col-lg-4">
+                <v-select
+                    name="institution_type"
+                    id="input_type"
+                    v-model="institution.institution_type_id"
+                    :options="institutionTypes"
+                    label="name"
+                    :reduce="institutionType => institutionType.id"
+                    :disabled="!canEdit"
 
-                    />
-                    <span class="text-danger emphasis show" role="alert"
-                          v-if="errors.hasOwnProperty('institution_type_id')">
+                />
+                <span class="text-danger emphasis show" role="alert"
+                      v-if="errors.hasOwnProperty('institution_type_id')">
                             <strong v-for="error in errors.institution_type_id">{{ error }}</strong><br/>
                         </span>
-                    <small id="institution_type_help" class="form-text font-sm">This can be used as an additional
-                        disaggregation for
-                        analysis of funding flows.</small>
-                </div>
+                <small id="institution_type_help" class="form-text font-sm">This can be used as an additional
+                    disaggregation for
+                    analysis of funding flows.</small>
             </div>
+        </div>
 
-            <div class="form-group row">
-                <label for="input_institution_type_other" class="col-sm-4 col-form-label text-right pr-2">Enter the
-                    'other' institution type:</label>
-                <div class="col-sm-8 col-lg-4">
-                    <input name="institution_type_other"
-                           class="form-control"
-                           id="institution_type_other"
-                           v-model="institution.institution_type_other"
-                           :disabled="institution.institution_type_id !== 5 || !canEdit"
-                    >
-                    <span class="text-danger emphasis show" role="alert"
-                          v-if="errors.hasOwnProperty('institution_type_other')">
+        <div class="form-group row">
+            <label for="input_institution_type_other" class="col-sm-4 col-form-label text-right pr-2">Enter the
+                'other' institution type:</label>
+            <div class="col-sm-8 col-lg-4">
+                <input name="institution_type_other"
+                       class="form-control"
+                       id="institution_type_other"
+                       v-model="institution.institution_type_other"
+                       :disabled="institution.institution_type_id !== 5 || !canEdit"
+                >
+                <span class="text-danger emphasis show" role="alert"
+                      v-if="errors.hasOwnProperty('institution_type_other')">
                         <strong v-for="error in errors.institution_type_other">{{ error }}</strong><br/>
                     </span>
-                </div>
             </div>
+        </div>
 
-            <div class="form-group row">
-                <label for="input_geographic_reach" class="col-sm-4 col-form-label text-right pr-2">What is the
-                    geographic reach of the institution?</label>
-                <div class="col-sm-8 col-lg-4">
-                    <v-select
-                        name="geographic_reach"
-                        id="input_geographic_reach"
-                        v-model="institution.geographic_reach"
-                        :options="geographicReaches"
-                        :disabled="!canEdit"
-                    />
-                    <span class="text-danger emphasis show" role="alert"
-                          v-if="errors.hasOwnProperty('geographic_reach')">
+        <div class="form-group row">
+            <label for="input_geographic_reach" class="col-sm-4 col-form-label text-right pr-2">What is the
+                geographic reach of the institution?</label>
+            <div class="col-sm-8 col-lg-4">
+                <v-select
+                    name="geographic_reach"
+                    id="input_geographic_reach"
+                    v-model="institution.geographic_reach"
+                    :options="geographicReaches"
+                    :disabled="!canEdit"
+                />
+                <span class="text-danger emphasis show" role="alert"
+                      v-if="errors.hasOwnProperty('geographic_reach')">
                             <strong v-for="error in errors.geographic_reach">{{ error }}</strong><br/>
                     </span>
-                </div>
             </div>
+        </div>
 
-            <div class="form-group row">
-                <label for="input_hq_country" class="col-sm-4 col-form-label text-right pr-2">What country is the
-                    institution HQ based?</label>
-                <div class="col-sm-8 col-lg-4">
-                    <v-select
-                        name="hq_country"
-                        id="input_hq_country"
-                        :options="countries"
-                        label="name"
-                        :reduce="country => country.id"
-                        v-model="institution.hq_country"
-                        :disabled="!canEdit"
-                    />
-                    <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('hq_country')">
+        <div class="form-group row">
+            <label for="input_hq_country" class="col-sm-4 col-form-label text-right pr-2">What country is the
+                institution HQ based?</label>
+            <div class="col-sm-8 col-lg-4">
+                <v-select
+                    name="hq_country"
+                    id="input_hq_country"
+                    :options="countries"
+                    label="name"
+                    :reduce="country => country.id"
+                    v-model="institution.hq_country"
+                    :disabled="!canEdit"
+                />
+                <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('hq_country')">
                             <strong v-for="error in errors.hq_country">{{ error }}</strong><br/>
                         </span>
-                </div>
             </div>
+        </div>
 
-            <div class="form-group d-flex justify-content-end mt-16"
-                 v-if="canEdit">
-                <button type="cancel" class="btn btn-secondary mr-4">Discard Changes</button>
-                <button class="btn btn-primary" @click="save">Save</button>
-            </div>
+        <div class="form-group d-flex justify-content-end mt-16"
+             v-if="canEdit">
+            <button type="cancel" class="btn btn-secondary mr-4">Discard Changes</button>
+            <button class="btn btn-primary" @click="save">Save</button>
+        </div>
 
     </div>
 
@@ -191,17 +191,15 @@ async function save() {
     try {
         const result = await axios.post(props.updateRoute, institution.value)
 
-        console.log(result)
-    } catch (error) {
+        new Noty({
+            type: "success",
+            text: "The Institution data was successfully saved"
+        }).show();
 
-        console.log(error)
+    } catch (error) {
         errors.value = error.response?.data.errors ?? {}
     }
 
-    new Noty({
-        type: "success",
-        text: "The Institution data was successfully saved"
-    }).show();
 }
 
 

--- a/resources/js/components/UserFeedbackForm.vue
+++ b/resources/js/components/UserFeedbackForm.vue
@@ -1,0 +1,157 @@
+<template>
+    <div class="card-header">
+        <h2>User Feedback</h2>
+        <p class="font-lg">Share feedback with the Site Management team</p>
+    </div>
+    <div class="card-body font-lg">
+        <p>If you encounter any technical issues while using the tool, please let us know here. You can contact us using the form below.</p>
+
+
+        <div class="card border border-info mt-4">
+            <div class="card-header">
+                <h3>Submit Feedback</h3>
+            </div>
+            <div class="card-body">
+                <div class="form-group row mt-8">
+                    <label for="input_hq_country" class="col-sm-4 col-form-label text-right pr-2">What type of feedback do you want to submit?</label>
+                    <div class="col-sm-8 col-lg-4">
+                        <v-select
+                            name="user_feedback_type"
+                            id="input_type"
+                            :options="userFeedbackTypes"
+                            label="name"
+                            :reduce="type => type.id"
+                            v-model="form.user_feedback_type_id"
+                        />
+                        <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('user_feedback_type_id')">
+                            <strong v-for="error in errors.user_feedback_type_id">{{ error }}</strong><br/>
+                        </span>
+                    </div>
+                </div>
+                <div class="form-group row mt-8">
+                    <label for="input_hq_country" class="col-sm-4 col-form-label text-right pr-2">Enter your message</label>
+
+                    <div class="col-sm-8">
+                    <textarea
+                        name="message"
+                        id="input_message"
+                        v-model="form.message"
+                        class="w-100"
+                        rows="7"
+                    />
+                        <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('message')">
+                            <strong v-for="error in errors.message">{{ error }}</strong><br/>
+                        </span>
+                    </div>
+                </div>
+
+                <div class="form-group row mt-8">
+                    <label for="input_hq_country" class="col-sm-4 col-form-label text-right pr-2">If you have any screenshots to support your feedback, please upload them here</label>
+
+                    <div class="col-sm-8">
+                        <media-library-collection name="uploads" @change="changeMedia" ref="mediaCollectionComponent"/>
+                        <span class="text-danger emphasis show" role="alert" v-if="errors.hasOwnProperty('message')">
+                            <strong v-for="error in errors.message">{{ error }}</strong><br/>
+                        </span>
+                    </div>
+                </div>
+
+                <div class="form-group row mt-4">
+                    <div class="col-sm-8 offset-sm-4">
+                        <div class="form-check">
+                            <input
+                                id="input_include_details"
+                                name="input_include_details"
+                                class="form-check-input"
+                                type="checkbox"
+                                v-model="includeDetails"
+                            >
+                            <label class="form-check-label" for="input_include_details">
+                                Do you want to include your user details along with the feedback?<br/><br/>
+                                <span class="font-md">This is optional - you may submit feedback anonymously if you wish. If you do share your details, your user account will be associated with this feedback. This will allow us to followup with you for further information, or reach out to provide support if possible.</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group d-flex justify-content-end mt-0"
+                >
+                    <button type="cancel" class="btn btn-secondary mr-4">Cancel</button>
+                    <button class="btn btn-primary" @click="save">Submit</button>
+                </div>
+
+            </div>
+        </div>
+
+    </div>
+</template>
+
+<script setup>
+
+import {ref, watch} from "vue";
+import 'vue-select/dist/vue-select.css'
+import vSelect from "vue-select";
+import Swal from "sweetalert2";
+
+import {MediaLibraryCollection} from "spatie-media-library-pro/media-library-pro-vue3-collection";
+
+
+const props = defineProps({
+    user: Object,
+    postRoute: String,
+    userFeedbacks: Array,
+    userFeedbackTypes: Array,
+});
+
+const errors = ref({})
+const form = ref({})
+
+async function save() {
+    try {
+
+        // merge main form with file uploads
+        let uploadForm = form.value;
+        uploadForm.uploads = uploads.value;
+
+        await axios.post(props.postRoute, uploadForm);
+
+        await Swal.fire({
+            title: "Thank you for your Feedback",
+            text: "Your message has been submitted, and will be reviewed by the Site Management team."
+        });
+
+
+        // reset form
+        form.value = {}
+        includeDetails.value = false;
+        mediaCollectionComponent.value.mediaLibrary.state.media = [];
+
+
+
+    } catch (error) {
+        errors.value = error.response?.data.errors ?? {}
+    }
+
+}
+
+// include details or not
+const includeDetails = ref(false);
+watch(includeDetails, (newValue) => {
+    console.log(newValue);
+    if (newValue) {
+        form.value.user_id = props.user.id;
+    } else {
+        delete form.value.user_id;
+    }
+})
+
+
+// track media
+const uploads = ref({});
+const mediaCollectionComponent = ref(null)
+function changeMedia(media) {
+    uploads.value = media;
+
+    console.log(mediaCollectionComponent.value.mediaLibrary)
+}
+
+</script>

--- a/resources/js/user-feedback.js
+++ b/resources/js/user-feedback.js
@@ -1,0 +1,10 @@
+import {createApp} from "vue/dist/vue.esm-bundler";
+
+import UserFeedbackForm from "./components/UserFeedbackForm.vue";
+import {Suspense} from "vue";
+
+
+createApp()
+    .component('UserFeedbackForm', UserFeedbackForm)
+    .component('Suspense', Suspense)
+    .mount('#user-feedback-form');

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,4 +1,6 @@
 @import url("https://fonts.googleapis.com/css?family=Hind");
+@import "../../vendor/spatie/laravel-medialibrary-pro/resources/js/media-library-pro-styles";
+
 @import "variables";
 
 @import "~@digitallyhappy/backstrap/src/scss/style";
@@ -7,6 +9,8 @@
 @import "~@digitallyhappy/backstrap/src/scss/_custom";
 @import "~line-awesome/dist/line-awesome/css/line-awesome.min.css";
 @import "~noty/src/noty";
+
+
 
 @import "backpack-form-tweaks";
 @import "redline-radios";

--- a/resources/views/emails/user_feedback_submitted.blade.php
+++ b/resources/views/emails/user_feedback_submitted.blade.php
@@ -1,0 +1,15 @@
+<x-mail::message>
+# {{ $feedback->type->name }} submitted for the {{ config('app.name') }}
+
+Someone has submitted a new piece of feedback:
+
+    - **Type**: {{ $feedback->type->name }}
+    - **Message**: {{  $feedback->message }}
+
+<x-mail::button :url="backpack_url('user-feedback')">
+Review Feedback
+</x-mail::button>
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/resources/views/organisations/settings.blade.php
+++ b/resources/views/organisations/settings.blade.php
@@ -9,8 +9,7 @@
     <form action="{{ route('organisation.self.update') }}" method="POST">
         @method('PUT')
         @csrf
-
-                    @foreach ($errors->all() as $error)
+            @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>
             @endforeach
 

--- a/resources/views/support.blade.php
+++ b/resources/views/support.blade.php
@@ -26,7 +26,7 @@
             <li class="nav-item" role="presentation">
                 <a href="#feedback" class="nav-link px-8 org-tab" id="feedback-tab" data-toggle="tab"
                    data-target="#feedback" type="button" role="tab" aria-controls="home" aria-selected="true">
-                    <h5 class="text-uppercase m-0 p-0">User Support</h5>
+                    <h5 class="text-uppercase m-0 p-0">User Feedback</h5>
                 </a>
             </li>
         </ul>
@@ -42,26 +42,72 @@
                 <div class="card-body font-lg">
 
                     <h3 class="pt-8">1. Training Resources</h3>
-                    <p>We have a series of short videos to guide new users through the setup process. You can watch the videos on the <a href="#resources">Training Resources tab</a> on this page.</p>
+                    <p>We have a series of short videos to guide new users through the setup process. You can watch the videos on the
+                        <a href="#resources" onclick="switchtab('resources')">Training Resources tab</a> on this page.
+                    </p>
 
                     <hr/>
 
                     <h3 class="pt-8">2. Institutional Support</h3>
-                    @if(\Illuminate\Support\Facades\Auth::user()->hasAnyRole(['Institutional Assessor', 'Institutional Member']))
-                        To get support within your own institution, you may contact an administrator for your institution:
+                    @if(Auth::user()->hasAnyRole(['Institutional Assessor', 'Institutional Member', 'Institutional Admin']))
+                        @if(Auth::user()->hasAnyRole(['Institutional Assessor', 'Institutional Member']))
+                            To get support within your own institution, you may contact an administrator for your institution:
+                        @elseif(Auth::user()->hasRole('Institutional Admin'))
+                            As an institutional administrator, you have full access to your institution's data, and can field support requests from other members. If you have questions about the use of the tool, the other resources on this page may help. For reference, your institution's administrators are:
+                        @endif
 
-                        <ul>
-                            @foreach(Organisation::find(Session::get('selectedOrganisationId'))->admins as $admin)
-                                <li>{{ $admin->name }}: {{ $admin->email }}</li>
+                        <ul class="list-group mt-4">
+                            @foreach(\App\Models\Organisation::find(Session::get('selectedOrganisationId'))->admins as $admin)
+                                <li class="list-group-item d-flex">
+                                    <span class="w-25 text-right mr-4" style="min-width: 150px">{{ $admin->name }}:</span>
+                                    <span><a href="mailto:{{ $admin->email }}">{{ $admin->email }}</a></span>
+                                </li>
                             @endforeach
                         </ul>
-                    @elseif(Auth::user()->hasRole('Institutional Admin'))
-                        As an institutional administrator, you have full access to your institution's data, and can field support requests from other members. If you have questions about the use of the tool, the other resources on this page may help
                     @else
-                        As a site manager or administrator, you can access and provide support to any of the institutions registered on the platform.
+                        As a site manager or administrator, you can access and provide support to any of the institutions registered on the platform. For institutional users, this section lists the Institutional Administrator users so they can get in touch for internal support.
                     @endif
+
+                    <hr/>
+
+                    <h3 class="pt-8">3. User Feedback</h3>
+                    <p>If you encounter any technical issues while using the tool, please contact us. Our site managers may be able to help, and bug reports will be forwarded onto our technical team. See the <a href="#feedback" onclick="switchtab('feedback')">User Feedback tab</a> for details.</p>
                 </div>
             </div>
+            <div class="tab-pane fade" id="resources" role="tabpanel" aria-labelledby="resources-tab">
+                <div class="card-header">
+                    <h2>Online Resources</h2>
+                    <p class="font-lg">We have developed a series of training videos for new users, available below.</p>
+                </div>
+
+                <div class="card-body w-75">
+
+                    <h3>Video 1: Registration and User Management</h3>
+                    <p class="mb-4">This video provides an introduction to the platform and explains how to register as a new user. It also provides an overview of the different user roles available, so may be useful to help decide what roles to give users within your own institution.</p>
+                    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/H982800IwwY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+                    <hr/>
+
+                    <h3>Video 2: Creating Initiatives</h3>
+                    <p class="mb-4">This video demonstrates the process of adding new initiatives to the platform.</p>
+                    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/pnKAfYKPvOQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+                    <hr/>
+                    <h3>Video 3: Assessing Initiatives </h3>
+                    <p class="mb-4">This video demonstrates the process of assessing your initiatives using the tool.</p>
+                    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/7ph03W87WQY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="feedback" role="tabpanel" aria-labelledby="feedback-tab">
+                <div id="user-feedback-form">
+                    <user-feedback-form
+                        :user="{{ Auth::user()->toJson()}}"
+                        post-route="{{ url('admin/user-feedback') }}"
+                        :user-feedback-types="{{ \App\Models\UserFeedbackType::all()->toJson() }}"
+                    >
+                </div>
+
         </div>
 
     </div>
@@ -70,7 +116,7 @@
 
 
 @section('after_scripts')
-    @vite(['resources/js/app.js', 'resources/js/institutions.js'])
+    @vite(['resources/js/app.js', 'resources/js/user-feedback.js'])
 
 
     <script>
@@ -112,6 +158,13 @@
                 'trigger': 'hover click',
             })
         });
+
+
+        function switchtab(tabname) {
+
+            var tabid = tabname + '-tab'
+            $('#'+tabid).tab('show')
+        }
     </script>
 
 @endsection

--- a/resources/views/support.blade.php
+++ b/resources/views/support.blade.php
@@ -49,6 +49,7 @@
                     <hr/>
 
                     <h3 class="pt-8">2. Institutional Support</h3>
+                    <h5>{{ \App\Models\Organisation::find(Session::get('selectedOrganisationId'))->name }}</h5>
                     @if(Auth::user()->hasAnyRole(['Institutional Assessor', 'Institutional Member', 'Institutional Admin']))
                         @if(Auth::user()->hasAnyRole(['Institutional Assessor', 'Institutional Member']))
                             To get support within your own institution, you may contact an administrator for your institution:
@@ -71,7 +72,9 @@
                     <hr/>
 
                     <h3 class="pt-8">3. User Feedback</h3>
-                    <p>If you encounter any technical issues while using the tool, please contact us. Our site managers may be able to help, and bug reports will be forwarded onto our technical team. See the <a href="#feedback" onclick="switchtab('feedback')">User Feedback tab</a> for details.</p>
+                    <p>If you encounter any technical issues while using the tool, please contact us. Our site managers may be able to help, and bug reports will be forwarded onto our technical team. See the
+                        <a href="#feedback" onclick="switchtab('feedback')">User Feedback tab</a> for details.
+                    </p>
                 </div>
             </div>
             <div class="tab-pane fade" id="resources" role="tabpanel" aria-labelledby="resources-tab">
@@ -108,15 +111,15 @@
                     >
                 </div>
 
+            </div>
+
         </div>
 
-    </div>
-
-@endsection
+        @endsection
 
 
-@section('after_scripts')
-    @vite(['resources/js/app.js', 'resources/js/user-feedback.js'])
+        @section('after_scripts')
+            @vite(['resources/js/app.js', 'resources/js/user-feedback.js'])
 
 
     <script>

--- a/resources/views/support.blade.php
+++ b/resources/views/support.blade.php
@@ -1,0 +1,117 @@
+@extends('backpack::layouts.top_left')
+
+@section('content')
+
+    <div class="mt-16 container-fluid">
+
+        <div class="w-100 mb-4">
+            <h1 class="text-deep-green">
+                <b>Support and User Feedback</b>
+            </h1>
+        </div>
+
+        <ul class="nav nav-tabs mt-4" id="org-tabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <a href="#support" class="nav-link px-8 org-tab" id="support-tab" data-toggle="tab"
+                   data-target="#support" type="button" role="tab" aria-controls="home" aria-selected="true">
+                    <h5 class="text-uppercase m-0 p-0">Getting Support</h5>
+                </a>
+            </li>
+            <li class="nav-item" role="presentation">
+                <a href="#resources" class="nav-link px-8 org-tab" id="resources-tab" data-toggle="tab"
+                   data-target="#resources" type="button" role="tab" aria-controls="home" aria-selected="true">
+                    <h5 class="text-uppercase m-0 p-0">Training Resources</h5>
+                </a>
+            </li>
+            <li class="nav-item" role="presentation">
+                <a href="#feedback" class="nav-link px-8 org-tab" id="feedback-tab" data-toggle="tab"
+                   data-target="#feedback" type="button" role="tab" aria-controls="home" aria-selected="true">
+                    <h5 class="text-uppercase m-0 p-0">User Support</h5>
+                </a>
+            </li>
+        </ul>
+
+        <div class="tab-content" id="org-tabs-content">
+            <div class="tab-pane fade" id="support" role="tabpanel" aria-labelledby="support-tab">
+
+                <div class="card-header">
+                    <h2>Getting Support to use the tool</h2>
+                    <p class="font-lg">There are a number of ways you can get support in the use of this tool. This page provides some resources and points of contact, and also allows you to share feedback about the tool to the site management team.</p>
+                </div>
+
+                <div class="card-body font-lg">
+
+                    <h3 class="pt-8">1. Training Resources</h3>
+                    <p>We have a series of short videos to guide new users through the setup process. You can watch the videos on the <a href="#resources">Training Resources tab</a> on this page.</p>
+
+                    <hr/>
+
+                    <h3 class="pt-8">2. Institutional Support</h3>
+                    @if(\Illuminate\Support\Facades\Auth::user()->hasAnyRole(['Institutional Assessor', 'Institutional Member']))
+                        To get support within your own institution, you may contact an administrator for your institution:
+
+                        <ul>
+                            @foreach(Organisation::find(Session::get('selectedOrganisationId'))->admins as $admin)
+                                <li>{{ $admin->name }}: {{ $admin->email }}</li>
+                            @endforeach
+                        </ul>
+                    @elseif(Auth::user()->hasRole('Institutional Admin'))
+                        As an institutional administrator, you have full access to your institution's data, and can field support requests from other members. If you have questions about the use of the tool, the other resources on this page may help
+                    @else
+                        As a site manager or administrator, you can access and provide support to any of the institutions registered on the platform.
+                    @endif
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+@endsection
+
+
+@section('after_scripts')
+    @vite(['resources/js/app.js', 'resources/js/institutions.js'])
+
+
+    <script>
+        $(document).ready(() => {
+
+            let url = location.href.replace(/\/$/, "");
+
+            if (location.hash) {
+                const hash = url.split("#");
+                $('#org-tabs a[href="#' + hash[1] + '"]').tab("show");
+                url = location.href.replace(/\/#/, "#");
+                history.replaceState(null, null, url);
+                setTimeout(() => {
+                    $(window).scrollTop(0);
+                }, 400);
+            } else {
+                $('#org-tabs a[href="#support"]').tab("show");
+                url = location.href.replace(/\/#/, "#");
+                history.replaceState(null, null, url);
+                setTimeout(() => {
+                    $(window).scrollTop(0);
+                }, 400);
+            }
+
+            $('a.org-tab').on("click", function () {
+                let newUrl;
+                const hash = $(this).attr("href");
+                if (hash == "#members") {
+                    newUrl = url.split("#")[0];
+                } else {
+                    newUrl = url.split("#")[0] + hash;
+                }
+                newUrl += "/";
+                history.replaceState(null, null, newUrl);
+            });
+
+            // enable hover tooltips
+            $('[data-toggle="popover"]').popover({
+                'trigger': 'hover click',
+            })
+        });
+    </script>
+
+@endsection

--- a/resources/views/user-feedback/details_row.blade.php
+++ b/resources/views/user-feedback/details_row.blade.php
@@ -12,15 +12,32 @@
 
         <ul class="list-group w-50" style="min-width: 500px">
 
-        @foreach($entry->getMedia() as $media)
-           <li class="list-group-item">
-               <a href="{{$media->getUrl()}}">
-                   {{ $media->name }}
-               </a>
-           </li>
-        @endforeach
+            @foreach($entry->getMedia() as $media)
+                <li class="list-group-item">
+                    <a href="{{$media->getUrl()}}">
+                        {{ $media->name }}
+                    </a>
+                </li>
+            @endforeach
         </ul>
 
+    @endif
+
+    <h3 class="mt-4">Site Manager Comments</h3>
+    @if($entry->comments->count() === 0)
+        There are no comments for this feedback item.
+    @else
+
+        <ul class="list-group w-50" style="min-width: 500px">
+
+            @foreach($entry->comments as $comment)
+                <li class="list-group-item">
+                    <b>{{ $comment->user->email }}:</b> <br/>
+                    {{ $comment->message }}
+
+                </li>
+            @endforeach
+        </ul>
     @endif
 
 </div>

--- a/resources/views/user-feedback/details_row.blade.php
+++ b/resources/views/user-feedback/details_row.blade.php
@@ -1,7 +1,26 @@
 <div>
-    {{ $entry->user->name }}
-<br/><br/>
-    {{ $entry->text }}
-<br/><br/>
-    {{ $entry->status }}
+    <h3>Message:</h3>
+    {{ $entry->message }}
+    <br/><br/>
+
+
+    <h3>Attachments</h3>
+
+    @if($entry->getMedia()->count() === 0)
+        There are no attachments to this feedback item.
+    @else
+
+        <ul class="list-group w-50" style="min-width: 500px">
+
+        @foreach($entry->getMedia() as $media)
+           <li class="list-group-item">
+               <a href="{{$media->getUrl()}}">
+                   {{ $media->name }}
+               </a>
+           </li>
+        @endforeach
+        </ul>
+
+    @endif
+
 </div>

--- a/resources/views/user-feedback/details_row.blade.php
+++ b/resources/views/user-feedback/details_row.blade.php
@@ -1,0 +1,7 @@
+<div>
+    {{ $entry->user->name }}
+<br/><br/>
+    {{ $entry->text }}
+<br/><br/>
+    {{ $entry->status }}
+</div>

--- a/resources/views/vendor/backpack/base/inc/menu.blade.php
+++ b/resources/views/vendor/backpack/base/inc/menu.blade.php
@@ -39,11 +39,10 @@
 
         <li class="nav-item pr-4">
             <a class="nav-link d-flex justify-content-between align-items-center"
-               href="https://www.youtube.com/playlist?list=PLK5PktXR1tmPMHKN6PnfY4jz9Cj_7L1E_"
-               target="_blank"
+               href="{{ backpack_url('support') }}"
             >
                 <i class="la la-question-circle font-3xl pr-2"></i>
-                <span>Video Guides</span>
+                <span>Support</span>
             </a>
         </li>
 

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -137,3 +137,5 @@ E.g., Centralise instituion selection to a single feature instead of distributin
 
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('initiative-category') }}"><i class="nav-icon la la-question"></i> Initiative categories</a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('institution-type') }}"><i class="nav-icon la la-question"></i> Institution types</a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('user-feedback') }}"><i class="nav-icon la la-question"></i> User feedback</a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('feedback-type') }}"><i class="nav-icon la la-question"></i> Feedback types</a></li>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -34,6 +34,7 @@ use App\Http\Controllers\OrganisationMemberController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\SelectedOrganisationController;
 use App\Http\Controllers\UserFeedbackController;
+use Backpack\CRUD\app\Http\Controllers\MyAccountController;
 
 
 Route::group([
@@ -132,20 +133,23 @@ Route::group([
 
         // download files
         Route::get('files/{filename}', [GeneratePdfFileController::class, 'download'])
-        ->where('filename', '.*');
+            ->where('filename', '.*');
 
         Route::crud('additional-criteria-score-tag', AdditionalCriteriaScoreTagCrudController::class);
+        Route::view('support', 'support');
 
+        Route::get('edit-account-info', [MyAccountController::class, 'getAccountInfoForm'])->name('backpack.account.info');
     });
 
 
+    Route::post('edit-account-info', [MyAccountController::class, 'postAccountInfoForm'])->name('backpack.account.info.store');
+    Route::post('change-password', [MyAccountController::class,'postChangePasswordForm'])->name('backpack.account.password');
     Route::crud('initiative-category', InitiativeCategoryCrudController::class);
     Route::crud('institution-type', InstitutionTypeCrudController::class);
     Route::crud('user-feedback', UserFeedbackCrudController::class);
     Route::post('user-feedback', [UserFeedbackController::class, 'store']);
     Route::crud('feedback-type', UserFeedbackTypeCrudController::class);
 
-    Route::view('support', 'support');
 });
 
 Route::get('project/{id}/show-as-pdf', [ProjectCrudController::class, 'show'])

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Admin\AdditionalCriteriaScoreTagCrudController;
 use App\Http\Controllers\Admin\AssessmentCrudController;
 use App\Http\Controllers\Admin\ContinentCrudController;
 use App\Http\Controllers\Admin\CountryCrudController;
+use App\Http\Controllers\Admin\UserFeedbackTypeCrudController;
 use App\Http\Controllers\Admin\InitiativeCategoryCrudController;
 use App\Http\Controllers\Admin\InstitutionTypeCrudController;
 use App\Http\Controllers\Admin\OrganisationCrudController;
@@ -23,6 +24,7 @@ use App\Http\Controllers\Admin\RemovalRequestCrudController;
 use App\Http\Controllers\Admin\RoleInviteCrudController;
 use App\Http\Controllers\Admin\ScoreTagCrudController;
 use App\Http\Controllers\Admin\UserCrudController;
+use App\Http\Controllers\Admin\UserFeedbackCrudController;
 use App\Http\Controllers\AssessmentController;
 use App\Http\Controllers\GeneratePdfFileController;
 use App\Http\Controllers\GenericDashboardController;
@@ -138,6 +140,10 @@ Route::group([
 
     Route::crud('initiative-category', InitiativeCategoryCrudController::class);
     Route::crud('institution-type', InstitutionTypeCrudController::class);
+    Route::crud('user-feedback', UserFeedbackCrudController::class);
+    Route::crud('feedback-type', UserFeedbackTypeCrudController::class);
+
+    Route::view('support', 'support');
 });
 
 Route::get('project/{id}/show-as-pdf', [ProjectCrudController::class, 'show'])

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\OrganisationController;
 use App\Http\Controllers\OrganisationMemberController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\SelectedOrganisationController;
+use App\Http\Controllers\UserFeedbackController;
 
 
 Route::group([
@@ -141,6 +142,7 @@ Route::group([
     Route::crud('initiative-category', InitiativeCategoryCrudController::class);
     Route::crud('institution-type', InstitutionTypeCrudController::class);
     Route::crud('user-feedback', UserFeedbackCrudController::class);
+    Route::post('user-feedback', [UserFeedbackController::class, 'store']);
     Route::crud('feedback-type', UserFeedbackTypeCrudController::class);
 
     Route::view('support', 'support');

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,3 +31,7 @@ Route::post('exchange-rate', [ExchangeRateController::class, 'index']);
 
 
 require __DIR__.'/auth.php';
+
+Route::middleware('auth')->group(function() {
+    Route::mediaLibrary();
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
                 'resources/js/dashboard.js',
                 'resources/js/initiatives.js',
                 'resources/js/institutions.js',
+                'resources/js/user-feedback.js',
                 'resources/js/assess.js',
                 'resources/js/dashboard-temp.js',
             ],
@@ -34,6 +35,10 @@ export default defineConfig({
             {
                 find: /^~(.*)$/,
                 replacement: '$1',
+            },
+            {
+                find: 'spatie-media-library-pro',
+                replacement: '/vendor/spatie/laravel-medialibrary-pro/resources/js',
             },
         ],
     },


### PR DESCRIPTION
This fixes #151.

## User Feedback
This PR does a number of things:

### Data Handling
1. It creates a new UserFeedback model, with related UserFeedbackType and UserFeedbackComment models.

 - a user feedback entry can be linked to a user (optional). 
 - it always has a "type" (e.g. "bug", "feature request" or "general feedback")
 - it can have many comments (which are comments added by Site managers or admins).

2. User Feedback items can also have media items attached to it. Spatie's Media Library + Pro are installed to handle this. 
3. User Feedback items are created through a Vue component form via the main front end. 
4. The CRUD controller is only for site managers / admins to review the feedback and edit to add their own comments. 

### Front End

The Videos link is now replaced with a `Support` link. This takes the user to a new page with different support options: 
<img width="1417" alt="CleanShot 2023-07-20 at 17 06 22@2x" src="https://github.com/stats4sd/aec_portfolio/assets/5711101/2d6cdfa0-873c-4676-909c-f8a5e2325533">


The **General Support** tab describes how to get support. Point 2 (Instutional Support) is different based on the current user's role. For Institutional Assessors and Members, this section lists the Institutional Admins for the current institution, with the suggestion that they can contact those admins for "internal" support. 

The Training resources tab links to and embeds the YouTube Videos.

The User Feedback tab contains a contact form for users to share feedback with Site Managers. 

### CRUD Panel
Right now, you need to manually go to `/admin/user-feedback` to get to the CRUD panel. This will change when we re-enable the sidebar / CRUD panel links for Site Managers + Admins. 

<img width="1237" alt="CleanShot 2023-07-20 at 17 13 50@2x" src="https://github.com/stats4sd/aec_portfolio/assets/5711101/9ef4d952-8edb-4714-a266-09e8179324d8">

The table shows the key details of the feedback item. There is a details_row that shows the message, any attachments and any added manager comments. The Edit function enables addition / editing of all attached comments. 


## TODO + FUTURE

TODO Now: 

- [x] Setup email that goes to site managers and admins when someone submits feedback.

Possible updates in future

- Right now, the "manager's comments" feature is quite limited. The idea is that people can add thoughts, comments or actions taken in a free-form way, as a basic form of tracking issues / feedback items. Problems include:
  - Any site manager or admin can edit anyone else's comments, and so the system relies on their being a small number of managers who are confident in the use of the system. 
  - There's no formal "this issue is resolved" way of tracking things.
  - There is no notification when someone adds a comment. 

I think all these issues are beyond the scope of what we should be doing at this stage. I believe the current implimentation fits the terms in the Tech Spec document and works well enough to allow users of the platform to formally register bugs, reequests or comments, and for us (Site managers) to review all the submitted feedback in one central location. 


