### PR TITLE
edits button label and removes save operations

### DIFF
--- a/app/Http/Controllers/Admin/AdditionalCriteriaCrudController.php
+++ b/app/Http/Controllers/Admin/AdditionalCriteriaCrudController.php
@@ -135,6 +135,8 @@ class AdditionalCriteriaCrudController extends CrudController
                 ],
             ]);
 
+            CRUD::removeSaveActions(['save_and_edit','save_and_new', 'save_and_preview']);
+
     }
 
     protected function setupUpdateOperation()

--- a/resources/views/organisations/additional-criteria.blade.php
+++ b/resources/views/organisations/additional-criteria.blade.php
@@ -25,7 +25,7 @@
                 <td>
                     <div class="btn-group">
 
-                        <a href="{{ route('additional-criteria.show', $additionalCriteria) }}" class="btn btn-success btn-sm">REVIEW</a>
+                        <a href="{{ route('additional-criteria.show', $additionalCriteria) }}" class="btn btn-success btn-sm">VIEW</a>
                         @if(Auth::user()->can('maintain portfolios'))
                             <a href="{{ route('additional-criteria.edit', [$additionalCriteria]) }}" class="btn btn-info btn-sm">EDIT</a>
                             <button class="btn btn-danger btn-sm remove-button" data-portfolio="{{ $additionalCriteria->id }}" data-toggle="modal" data-target="#removeAdditionalCriteriaModal{{ $additionalCriteria->id }}">REMOVE</button>


### PR DESCRIPTION
This PR updates the additional criteria crud by:
- renaming the 'review' button as 'view'
- removing the extra save actions to just have 'save and back'

fixes #163 