### PR TITLE
On the My Institution page, store the user's tab in Session for later

### DIFF
--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -11,6 +11,7 @@ use App\Models\InstitutionType;
 use App\Models\Organisation;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
 
 class OrganisationController extends Controller
@@ -33,12 +34,16 @@ class OrganisationController extends Controller
         $geographicReaches = GeographicalReach::cases();
         $countries = Country::all();
 
+        // get session stored tab
+        $tab = Str::replace('#', '', Session::get('organisation.tab'));
+
 
         return view('organisations.show', [
             'organisation' => $organisation,
             'institutionTypes' => $institutionTypes,
             'geographicReaches' => $geographicReaches,
             'countries' => $countries,
+            'tab' => $tab,
         ]);
 
     }
@@ -88,5 +93,12 @@ class OrganisationController extends Controller
         return Excel::download(new MergedExport(), 'test.xlsx');
     }
 
+
+    public function storeTab()
+    {
+        Session::put('organisation.tab', request()?->get('tab'));
+
+        return response('success', 200);
+    }
 
 }

--- a/resources/js/institutions.js
+++ b/resources/js/institutions.js
@@ -2,6 +2,9 @@ import {createApp} from 'vue/dist/vue.esm-bundler';
 
 import InstitutionSettings from "./components/InstitutionSettings.vue"
 import {Suspense} from "vue";
+import axios from "axios";
+
+
 
 createApp()
     .component('InstitutionSettings', InstitutionSettings)

--- a/resources/views/organisations/show.blade.php
+++ b/resources/views/organisations/show.blade.php
@@ -6,6 +6,8 @@
 
         <div class="w-100 mb-4">
             <h1 class="text-deep-green"><b>{{$organisation->name}} - Information</b></h1>
+
+            <h3>{{ $tab }}</h3>
         </div>
 
         <ul class="nav nav-tabs mt-4" id="org-tabs" role="tablist">
@@ -88,7 +90,11 @@
                     $(window).scrollTop(0);
                 }, 400);
             } else {
-                $('#org-tabs a[href="#portfolios"]').tab("show");
+
+                let tab = "{{ $tab }}"
+
+                // get from session storage
+                $('#org-tabs a[href="#'+tab+'"]').tab("show");
                 url = location.href.replace(/\/#/, "#");
                 history.replaceState(null, null, url);
                 setTimeout(() => {
@@ -106,6 +112,9 @@
                 }
                 newUrl += "/";
                 history.replaceState(null, null, newUrl);
+
+                // update session storage
+                axios.post('/admin/organisation/store-tab', {tab: hash})
             });
 
             // enable hover tooltips

--- a/resources/views/organisations/show.blade.php
+++ b/resources/views/organisations/show.blade.php
@@ -6,8 +6,6 @@
 
         <div class="w-100 mb-4">
             <h1 class="text-deep-green"><b>{{$organisation->name}} - Information</b></h1>
-
-            <h3>{{ $tab }}</h3>
         </div>
 
         <ul class="nav nav-tabs mt-4" id="org-tabs" role="tablist">

--- a/resources/views/vendor/backpack/base/inc/menu.blade.php
+++ b/resources/views/vendor/backpack/base/inc/menu.blade.php
@@ -53,7 +53,7 @@
                 <i class="la la-user-circle font-3xl pr-2"></i>
                 <span>My Account</span>
             </a>
-        </li>J
+        </li>
 
         @if(\App\Models\Organisation::count() > 1)
         <li class="nav-item pr-4">

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -85,6 +85,8 @@ Route::group([
 
         Route::get('organisation/show', [OrganisationController::class, 'show'])->name('organisation.self.show');
         Route::get('organisation/export', [OrganisationController::class, 'export'])->name('organisation.export');
+        Route::post('organisation/store-tab', [OrganisationController::class, 'storeTab']);
+
 
         Route::crud('portfolio', PortfolioCrudController::class);
         Route::get('portfolio', function () {


### PR DESCRIPTION
This PR fixes #162, by updating the Session cache storage with the user's current tab. 

Previously, when returning to the My Institution page, the app would always reset to the Portfolios tab unless you specifically included a # in the url. This was particularly confusing when returning from any Additional criteria page, but more generally it's a nicer experience if the user goes back to the same place they left when returning to the page. 

This PR adds to the page's JS to retrieve the stored tab ONLY if there is no # in the url (to allow the user or custom links to overwrite it). It also sends an ajax request when the user changes tabs to update the sesson storage on the server. 

