### PR TITLE
Update system to include projects that failed all red flags as "completed"

### DIFF
--- a/app/Http/Controllers/Admin/Operations/RedlineOperation.php
+++ b/app/Http/Controllers/Admin/Operations/RedlineOperation.php
@@ -119,6 +119,7 @@ trait RedlineOperation
             if ($latestAssessment->failingRedlines()->count() > 0) {
                 $latestAssessment->redline_status = AssessmentStatus::Failed;
                 $latestAssessment->principle_status = AssessmentStatus::Complete;
+                $latestAssessment->additional_status = AssessmentStatus::Complete;
                 $latestAssessment->completed_at = Carbon::now();
             } else {
                 $latestAssessment->redline_status = AssessmentStatus::Complete;

--- a/app/Http/Controllers/GenericDashboardController.php
+++ b/app/Http/Controllers/GenericDashboardController.php
@@ -272,12 +272,11 @@ class GenericDashboardController extends Controller
 
 
         // add overall score from PHP side because this is already calculated on the Assessment Model.
-        $allAssessments = Assessment::with('principles', 'failingRedlines')->whereIn('id', DB::table('dashboard_assessment')
-            ->select('assessment_id')
-            ->where('dashboard_id', $dashboardYoursId))
-            ->get();
+        $allAssessments = Project::with([
+            'assessments' => ['principles', 'failingRedlines']
+        ])->get()->pluck('assessments')->flatten();
 
-        $noOfInitiativeCompletedAssessment = $allAssessments->where('principle_status', '=', AssessmentStatus::Complete->value)->count();
+        $noOfInitiativeCompletedAssessment = $allAssessments->count();
 
         // initialise variables
         $assessmentScore = 'N/A';

--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -374,7 +374,8 @@ BEGIN
         SELECT COUNT(*)
         INTO ssFullyAssessedCount
         FROM assessments
-        WHERE completed_at IS NOT NULL
+        WHERE (assessments.redline_status = 'Failed'
+          OR assessments.principle_status = 'Complete')
           AND id IN
               (SELECT assessment_id FROM dashboard_assessment WHERE dashboard_id = dashboardYoursId);
 
@@ -385,7 +386,8 @@ BEGIN
         WHERE id IN
               (SELECT project_id
                from assessments
-               WHERE completed_at IS NOT NULL
+               WHERE (assessments.redline_status = 'Failed'
+                 OR assessments.principle_status = 'Complete')
                  AND id IN
                      (SELECT assessment_id FROM dashboard_assessment where dashboard_id = dashboardYoursId));
 

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -160,7 +160,10 @@ const nextAction = computed(() => {
     const additionalStatus = props.initiative.latest_assessment.additional_status
 
     if (redlineStatus === "Failed") {
-        return null;
+        return {
+            label: "Show information",
+            url: `/admin/project/${props.initiative.id}/show`,
+        }
     }
 
     if (redlineStatus !== "Complete") {

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -97,10 +97,12 @@
             </div>
 
             <div class="col-12 col-lg-6 print-8 d-flex justify-content-center align-items-center">
-                @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value)
+                @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value && $entry->latest_assessment->redline_status !== \App\Enums\AssessmentStatus::Failed->value)
                     <div id="radarChart"></div>
+                @elseif($entry->latest_assessment->redline_status === \App\Enums\AssessmentStatus::Failed->value)
+                    <p class="text-center text-secondary">~~ Red flag assessment failed ~~<br/>~~ no principle assessment results available ~~</p>
                 @else
-                    <p class="text-center text-secondary">~~ Principle Assessment not yet completed ~~<br/>~~ no results available ~~</p>
+                    <p class="text-center text-secondary">~~ Principle assessment not completed ~~<br/>~~ no results available ~~</p>
                 @endif
             </div>
         </div>


### PR DESCRIPTION
This fixes #186. Fixes #174 

This PR makes 3 visual changes in the same theme of "completion status".

According to the tool, assessments that fail the red flags should be considered "complete". This PR updates the system so that assessments with failed red flags:
- show the "show information" button on the list view;
- do *not* show the spider diagram on the show initiatives page;
- *are* included in the overall_score on the dashboard. 
  - previously, they were not included, so the overall score did not take those 0% values into account in the score or the AE directed budget. 

They are still not included in the principle assessment dashbaord tab.

### Screenshots

#### Red flags failed => now showing "show information" as main next action:
![CleanShot 2023-07-31 at 16 58 25](https://github.com/stats4sd/aec_portfolio/assets/5711101/22b8b8f4-deca-4a4d-8298-374dca8d44c8)


#### No spider chart shown when red flags are failed:
![CleanShot 2023-07-26 at 15 27 02](https://github.com/stats4sd/aec_portfolio/assets/5711101/08da740d-e0a5-46ea-a5ca-7be3aeb21562)

#### Initiative is not included in the principle summary:
![CleanShot 2023-07-26 at 15 26 58](https://github.com/stats4sd/aec_portfolio/assets/5711101/241c4c22-02c5-4e39-bd92-8e7ce8db89b4)


#### Initiative score *is* included in the overall_score:
(2 initiatives in the selected portfolio, 1 = failed red flags; other = ~57% score
![CleanShot 2023-07-31 at 17 21 55](https://github.com/stats4sd/aec_portfolio/assets/5711101/41f3be53-195d-4b66-9fd2-7e8d7d648dd1)
