### PR TITLE
Add Revision CRUD

### DIFF
--- a/app/Http/Controllers/Admin/RevisionCrudController.php
+++ b/app/Http/Controllers/Admin/RevisionCrudController.php
@@ -44,9 +44,9 @@ class RevisionCrudController extends CrudController
      */
     protected function setupListOperation()
     {
-        CRUD::column('project.organisation.id');
+        CRUD::column('project.organisation.id')->label('Institution ID');
 
-        CRUD::column('project.name')->label('Project');
+        CRUD::column('project.name')->label('Initiative');
 
         CRUD::column('item_type');
         CRUD::column('item');
@@ -72,14 +72,14 @@ class RevisionCrudController extends CrudController
         CRUD::column('created_at');
 
 
-        // TODO: add filter silently to show projects of selected organisation only?
+        // TODO: add filter silently to show initiatives of selected organisation only?
 
-        // add filter for project
+        // add filter for initiative
         $this->crud->addFilter(
             [
                 'type' => 'select2',
                 'name' => 'projects',
-                'label' => 'filter by project',
+                'label' => 'filter by initiative',
             ],
             function () {
                 return Project::where('organisation_id', Session::get('selectedOrganisationId'))->get()->pluck('name', 'id')->toArray();

--- a/app/Http/Controllers/Admin/RevisionCrudController.php
+++ b/app/Http/Controllers/Admin/RevisionCrudController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Models\Project;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
@@ -37,38 +36,9 @@ class RevisionCrudController extends CrudController
      */
     protected function setupListOperation()
     {
-
+        // do not remember user's filtering, search and pagination when user leave the page.
+        // it is to avoid keeping user selected initiative of institution A in filter after user changing to institution B
         CRUD::disablePersistentTable();
-
-        // Question: How to show revisions records belong to initiatives that belong to user selected organisation?
-        //
-        // In revisions table, there is no column to indicate which organisation it belongs to.
-        //
-        // We can only find out the corresponding organisation very indirectly,
-        // i.e. find Red Flag / Principle / Additional Criteria model => Assessment model => Project model => Organisation ID
-        //
-        // It seems that "CRUD::addClause()" cannot be used here as it can only specify condition for table columns directly.
-        //
-        //
-        // Possible workaround:
-        //
-        // 1. Based on user selected organisation id, find out all related records of red flag / principle / additional criteria,
-        // only show revisions record with matched revisionable_type and revisionable_id.
-        //
-        // It sounds complicated, and we may have performance issue when we have more and more records.
-        //
-        // 2. Do not show any revision records at the beginning. User must select an initiative then only show related revision
-        // records in list view. As the filter only shows initiatives belong to user selected organisation, the revisions records
-        // to be showed must belong to user selected organisation.
-        //
-        // This approach is simpler, and it is unlikely to have performance issue.
-        // But we may need to provide additioanl instructions on how to use this CRUD panel.
-
-
-        // add a clause that no revisions record will meet, it will return an empty set
-        // therefore no revisions record showed at the beginning
-        //CRUD::addClause('where', 'id', '=', 0);
-
 
         CRUD::column('project.name')->label('Initiative');
         CRUD::column('item_type');
@@ -114,9 +84,24 @@ class RevisionCrudController extends CrudController
             }
         );
 
-        // Maybe it is useful to add filter by item type here.
-        // But it may be complicated when user filter by item type without filtering by initiative.
-        // Consider this feature as a nice to have feature or future enhancement.
+        // add filter by item type
+        $this->crud->addFilter([
+            'name' => 'item_type',
+            'type' => 'dropdown',
+            'label' => 'Filter by Item Type'
+        ], [
+            0 => 'Red Flag',
+            1 => 'Principle',
+            2 => 'Additional Criteria',
+        ], function ($value) {
+            if ($value == 0) {
+                $this->crud->addClause('where', 'revisionable_type', 'App\Models\AssessmentRedLine');
+            } else if ($value == 1) {
+                $this->crud->addClause('where', 'revisionable_type', 'App\Models\PrincipleAssessment');
+            } else if ($value == 2) {
+                $this->crud->addClause('where', 'revisionable_type', 'App\Models\AdditionalCriteriaAssessment');
+            }
+        });
 
     }
 

--- a/app/Http/Controllers/Admin/RevisionCrudController.php
+++ b/app/Http/Controllers/Admin/RevisionCrudController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Requests\RevisionRequest;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+/**
+ * Class RevisionCrudController
+ * @package App\Http\Controllers\Admin
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class RevisionCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    // use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    // use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    // use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+    // use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+
+    /**
+     * Configure the CrudPanel object. Apply settings to all operations.
+     * 
+     * @return void
+     */
+    public function setup()
+    {
+        CRUD::setModel(\App\Models\Revision::class);
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/revision');
+        CRUD::setEntityNameStrings('revision', 'revisions');
+    }
+
+    /**
+     * Define what happens when the List operation is loaded.
+     * 
+     * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
+     * @return void
+     */
+    protected function setupListOperation()
+    {
+        CRUD::column('revisionable_type');
+        CRUD::column('revisionable_id');
+
+        $this->crud->addColumns([
+            [
+                'name' => 'user_id',
+                'label' => 'User',
+                'type' => 'select',
+                'entity' => 'user',
+                'attribute' => 'name',
+                'model' => User::class,
+                'wrapper' => [
+                    'element' => 'div',
+                    'width' => "200px",
+                ],
+            ],
+        ]);
+
+        // CRUD::column('user_id');
+
+        CRUD::column('key');
+        CRUD::column('old_value');
+        CRUD::column('new_value');
+        CRUD::column('created_at');
+        // CRUD::column('updated_at');
+
+        /**
+         * Columns can be defined using the fluent syntax or array syntax:
+         * - CRUD::column('price')->type('number');
+         * - CRUD::addColumn(['name' => 'price', 'type' => 'number']); 
+         */
+    }
+
+    // /**
+    //  * Define what happens when the Create operation is loaded.
+    //  * 
+    //  * @see https://backpackforlaravel.com/docs/crud-operation-create
+    //  * @return void
+    //  */
+    // protected function setupCreateOperation()
+    // {
+    //     CRUD::setValidation(RevisionRequest::class);
+
+    //     CRUD::field('revisionable_type');
+    //     CRUD::field('revisionable_id');
+    //     CRUD::field('user_id');
+    //     CRUD::field('key');
+    //     CRUD::field('old_value');
+    //     CRUD::field('new_value');
+
+    //     /**
+    //      * Fields can be defined using the fluent syntax or array syntax:
+    //      * - CRUD::field('price')->type('number');
+    //      * - CRUD::addField(['name' => 'price', 'type' => 'number'])); 
+    //      */
+    // }
+
+    // /**
+    //  * Define what happens when the Update operation is loaded.
+    //  * 
+    //  * @see https://backpackforlaravel.com/docs/crud-operation-update
+    //  * @return void
+    //  */
+    // protected function setupUpdateOperation()
+    // {
+    //     $this->setupCreateOperation();
+    // }
+}

--- a/app/Http/Controllers/Admin/RevisionCrudController.php
+++ b/app/Http/Controllers/Admin/RevisionCrudController.php
@@ -19,7 +19,7 @@ class RevisionCrudController extends CrudController
 
     /**
      * Configure the CrudPanel object. Apply settings to all operations.
-     * 
+     *
      * @return void
      */
     public function setup()
@@ -31,40 +31,43 @@ class RevisionCrudController extends CrudController
 
     /**
      * Define what happens when the List operation is loaded.
-     * 
+     *
      * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
      * @return void
      */
     protected function setupListOperation()
     {
+
+        CRUD::disablePersistentTable();
+
         // Question: How to show revisions records belong to initiatives that belong to user selected organisation?
         //
         // In revisions table, there is no column to indicate which organisation it belongs to.
         //
-        // We can only find out the corresponding organisation very indirectly, 
+        // We can only find out the corresponding organisation very indirectly,
         // i.e. find Red Flag / Principle / Additional Criteria model => Assessment model => Project model => Organisation ID
         //
         // It seems that "CRUD::addClause()" cannot be used here as it can only specify condition for table columns directly.
         //
         //
         // Possible workaround:
-        // 
+        //
         // 1. Based on user selected organisation id, find out all related records of red flag / principle / additional criteria,
         // only show revisions record with matched revisionable_type and revisionable_id.
         //
         // It sounds complicated, and we may have performance issue when we have more and more records.
-        // 
+        //
         // 2. Do not show any revision records at the beginning. User must select an initiative then only show related revision
-        // records in list view. As the filter only shows initiatives belong to user selected organisation, the revisions records 
+        // records in list view. As the filter only shows initiatives belong to user selected organisation, the revisions records
         // to be showed must belong to user selected organisation.
         //
-        // This approach is simpler, and it is unlikely to have performance issue. 
+        // This approach is simpler, and it is unlikely to have performance issue.
         // But we may need to provide additioanl instructions on how to use this CRUD panel.
 
 
         // add a clause that no revisions record will meet, it will return an empty set
         // therefore no revisions record showed at the beginning
-        CRUD::addClause('where', 'id', '=', 0);
+        //CRUD::addClause('where', 'id', '=', 0);
 
 
         CRUD::column('project.name')->label('Initiative');
@@ -102,41 +105,12 @@ class RevisionCrudController extends CrudController
             function () {
                 return Project::where('organisation_id', Session::get('selectedOrganisationId'))->get()->pluck('name', 'id')->toArray();
             },
-            function ($values) {
-                // find assessment red line ids belong to related assessments
-                $assessmentRedLineIds = DB::table("assessment_red_line")->select('id')->whereIn('assessment_id', function ($query) use ($values) {
-                    // find assessment_id belongs to selected project
-                    $query->select('id')->from('assessments')->where('project_id', $values);
-                })
-                ->pluck('id');
-
-                // find principle assessment ids belong to related assessments
-                $principleAssessmentIds = DB::table("principle_assessment")->select('id')->whereIn('assessment_id', function ($query) use ($values) {
-                    // find assessment_id belongs to selected project
-                    $query->select('id')->from('assessments')->where('project_id', $values);
-                })
-                ->pluck('id');
-
-                // find additional criteria assessment ids belong to related assessments
-                $additionalCriteriaAssessmentIds = DB::table("additional_criteria_assessment")->select('id')->whereIn('assessment_id', function ($query) use ($values) {
-                    // find assessment_id belongs to selected project
-                    $query->select('id')->from('assessments')->where('project_id', $values);
-                })
-                ->pluck('id');
-
-                // find revisions records related to selected initiative
-                // it will return empty set + selected project red flag revisions + selected project principle revisions + selected project additional criteria revisions
-                $this->crud->query->where('id', '0')
-                                ->orWhere(function($query1) use ($assessmentRedLineIds) {
-                                    $query1->where('revisionable_type', 'App\Models\AssessmentRedLine')->whereIn("revisionable_id", $assessmentRedLineIds);
-                                })
-                                ->orWhere(function($query2) use ($principleAssessmentIds) {
-                                    $query2->where('revisionable_type', 'App\Models\PrincipleAssessment')->whereIn("revisionable_id", $principleAssessmentIds);
-                                })
-                                ->orWhere(function($query3) use ($additionalCriteriaAssessmentIds) {
-                                    $query3->where('revisionable_type', 'App\Models\AdditionalCriteriaAssessment')->whereIn("revisionable_id", $additionalCriteriaAssessmentIds);
-                                });
-
+            function ($value) {
+                $this->crud->query->whereHas('revisionable', function($query) use ($value) {
+                    $query->whereHas('assessment', function($query) use ($value) {
+                        $query->where('project_id', $value);
+                    });
+                });
             }
         );
 

--- a/app/Http/Controllers/Admin/RevisionCrudController.php
+++ b/app/Http/Controllers/Admin/RevisionCrudController.php
@@ -119,7 +119,16 @@ class RevisionCrudController extends CrudController
                 $thirdQuery = Revision::where('revisionable_type', 'App\Models\AdditionalCriteriaAssessment')->whereIn("revisionable_id", $additionalCriteriaAssessmentIds);
 
                 // TODO: union 3 query results together
-                $this->crud->query->where('revisionable_type', 'App\Models\AssessmentRedLine')->whereIn("revisionable_id", $assessmentRedLineIds);
+                // $this->crud->query->where('revisionable_type', 'App\Models\AssessmentRedLine')->whereIn("revisionable_id", $assessmentRedLineIds);
+
+                // Question: how to pass $additionalCriteriaAssessmentIds into the funciton?
+                $this->crud->query->where('revisionable_type', 'App\Models\AssessmentRedLine')->whereIn("revisionable_id", $assessmentRedLineIds)
+                                ->orWhere(function($query1) {
+                                    $query1->where('revisionable_type', 'App\Models\PrincipleAssessment')->whereIn("revisionable_id", [7437,7438,7439,7440,7441,7442,7443,7444,7445,7446,7447,7448,7449]);
+                                })
+                                ->orWhere(function($query2) {
+                                    $query2->where('revisionable_type', 'App\Models\AdditionalCriteriaAssessment')->whereIn("revisionable_id", [243]);
+                                });
 
                 // TODO
                 // $this->crud->query = $secondQuery->union($thirdQuery);

--- a/app/Http/Controllers/Admin/RevisionCrudController.php
+++ b/app/Http/Controllers/Admin/RevisionCrudController.php
@@ -88,7 +88,7 @@ class RevisionCrudController extends CrudController
         $this->crud->addFilter([
             'name' => 'item_type',
             'type' => 'dropdown',
-            'label' => 'Filter by Item Type'
+            'label' => 'Filter by Item type'
         ], [
             0 => 'Red Flag',
             1 => 'Principle',

--- a/app/Http/Requests/RevisionRequest.php
+++ b/app/Http/Requests/RevisionRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RevisionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        // only allow updates if the user is logged in
+        return backpack_auth()->check();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            // 'name' => 'required|min:5|max:255'
+        ];
+    }
+
+    /**
+     * Get the validation attributes that apply to the request.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the validation messages that apply to the request.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Models/Revision.php
+++ b/app/Models/Revision.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Database\Eloquent\Builder;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
@@ -25,6 +24,8 @@ class Revision extends \Venturecraft\Revisionable\Revision
 
     protected static function booted()
     {
+        // add a global scope to only return entries for the selected organisation
+        // assumption: all 'revisionable' data models are related to the Assessment model
         static::addGlobalScope('organisation', function (Builder $query) {
             $query->whereHas('revisionable', function (Builder $query) {
                 $query->whereHas('assessment', function (Builder $query) {
@@ -84,10 +85,6 @@ class Revision extends \Venturecraft\Revisionable\Revision
 
     public function getProjectAttribute()
     {
-        // I did some searches in google and our projects, I cannot find example for reference...
-        // Um... cannot access the corresponding model's assessment model directly...
-        // logger($this->assessment->project);
-
         if ($this->revisionable_type == 'App\Models\AssessmentRedLine') {
             $assessmentRedLine = AssessmentRedLine::find($this->revisionable_id);
             return $assessmentRedLine->assessment->project;
@@ -100,7 +97,6 @@ class Revision extends \Venturecraft\Revisionable\Revision
             $additionalCriteriaAssessment = AdditionalCriteriaAssessment::find($this->revisionable_id);
             return $additionalCriteriaAssessment->assessment->project;
         }
-
     }
 
     public function getProjectIdAttribute()

--- a/app/Models/Revision.php
+++ b/app/Models/Revision.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Revision extends Model
@@ -21,6 +23,19 @@ class Revision extends Model
     protected $table = 'revisions';
     protected $guarded = ['id'];
 
+    protected static function booted()
+    {
+        // TODO: add global scope to filter by currently selected organisation.
+
+        // Unlike portfolio table and project table, there is no organisation_id column in revisions table.
+        // Question: How do we check this revision record is related to an organisation indirectly...
+        // Red flag / Principle / Additional Criteria -> assessment -> project -> organisation
+        // static::addGlobalScope('organisation',  function(Builder $query) {
+        //     $query->where('organisation_id', Session::get('selectedOrganisationId'));
+        // });
+
+    }
+
     /*
     |--------------------------------------------------------------------------
     | RELATIONS
@@ -31,5 +46,68 @@ class Revision extends Model
     {
         return $this->belongsTo(User::class);
     }
+
     
+    /*
+    |--------------------------------------------------------------------------
+    | FUNCTIONS
+    |--------------------------------------------------------------------------
+    */
+
+    public function getItemTypeAttribute() {
+        if ($this->revisionable_type == 'App\Models\AssessmentRedLine') {
+            return 'Red Flag';
+        } else if ($this->revisionable_type == 'App\Models\PrincipleAssessment') {
+            return 'Principle';
+        } else if ($this->revisionable_type == 'App\Models\AdditionalCriteriaAssessment') {
+            return 'Additional Criteria'; 
+        }
+    }
+
+    public function getItemAttribute() {
+        if ($this->revisionable_type == 'App\Models\AssessmentRedLine') {
+            $assessmentRedLine = AssessmentRedLine::find($this->revisionable_id);
+            return $assessmentRedLine->redLine->name;
+
+        } else if ($this->revisionable_type == 'App\Models\PrincipleAssessment') {
+            $principleAssessment = PrincipleAssessment::find($this->revisionable_id);
+            return $principleAssessment->principle->name;
+
+        } else if ($this->revisionable_type == 'App\Models\AdditionalCriteriaAssessment') {
+            $additionalCriteriaAssessment = AdditionalCriteriaAssessment::find($this->revisionable_id);
+            return $additionalCriteriaAssessment->additionalCriteria->name;
+
+        }
+    }
+
+    public function getProjectAttribute() {
+        if ($this->revisionable_type == 'App\Models\AssessmentRedLine') {
+            $assessmentRedLine = AssessmentRedLine::find($this->revisionable_id);
+            return $assessmentRedLine->assessment->project;
+
+        } else if ($this->revisionable_type == 'App\Models\PrincipleAssessment') {
+            $principleAssessment = PrincipleAssessment::find($this->revisionable_id);
+            return $principleAssessment->assessment->project;
+
+        } else if ($this->revisionable_type == 'App\Models\AdditionalCriteriaAssessment') {
+            $additionalCriteriaAssessment = AdditionalCriteriaAssessment::find($this->revisionable_id);
+            return $additionalCriteriaAssessment->assessment->project;
+        }
+    }
+
+    public function getProjectIdAttribute() {
+        if ($this->revisionable_type == 'App\Models\AssessmentRedLine') {
+            $assessmentRedLine = AssessmentRedLine::find($this->revisionable_id);
+            return $assessmentRedLine->assessment->project->id;
+
+        } else if ($this->revisionable_type == 'App\Models\PrincipleAssessment') {
+            $principleAssessment = PrincipleAssessment::find($this->revisionable_id);
+            return $principleAssessment->assessment->project->id;
+
+        } else if ($this->revisionable_type == 'App\Models\AdditionalCriteriaAssessment') {
+            $additionalCriteriaAssessment = AdditionalCriteriaAssessment::find($this->revisionable_id);
+            return $additionalCriteriaAssessment->assessment->project->id;
+        }
+    }
+
 }

--- a/app/Models/Revision.php
+++ b/app/Models/Revision.php
@@ -2,14 +2,15 @@
 
 namespace App\Models;
 
-use Backpack\CRUD\app\Models\Traits\CrudTrait;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Database\Eloquent\Builder;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Venturecraft\Revisionable\Revisionable;
 
-class Revision extends Model
+class Revision extends Revisionable
 {
     use CrudTrait;
     use HasFactory;
@@ -23,18 +24,6 @@ class Revision extends Model
     protected $table = 'revisions';
     protected $guarded = ['id'];
 
-    protected static function booted()
-    {
-        // TODO: add global scope to filter by currently selected organisation.
-
-        // Unlike portfolio table and project table, there is no organisation_id column in revisions table.
-        // Question: How do we check this revision record is related to an organisation indirectly...
-        // Red flag / Principle / Additional Criteria -> assessment -> project -> organisation
-        // static::addGlobalScope('organisation',  function(Builder $query) {
-        //     $query->where('organisation_id', Session::get('selectedOrganisationId'));
-        // });
-
-    }
 
     /*
     |--------------------------------------------------------------------------
@@ -81,6 +70,10 @@ class Revision extends Model
     }
 
     public function getProjectAttribute() {
+        // I did some searches in google and our projects, I cannot find example for reference...
+        // Um... cannot access the corresponding model's assessment model directly...
+        // logger($this->assessment->project);
+
         if ($this->revisionable_type == 'App\Models\AssessmentRedLine') {
             $assessmentRedLine = AssessmentRedLine::find($this->revisionable_id);
             return $assessmentRedLine->assessment->project;
@@ -93,6 +86,7 @@ class Revision extends Model
             $additionalCriteriaAssessment = AdditionalCriteriaAssessment::find($this->revisionable_id);
             return $additionalCriteriaAssessment->assessment->project;
         }
+        
     }
 
     public function getProjectIdAttribute() {

--- a/app/Models/Revision.php
+++ b/app/Models/Revision.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Revision extends Model
+{
+    use CrudTrait;
+    use HasFactory;
+
+    /*
+    |--------------------------------------------------------------------------
+    | GLOBAL VARIABLES
+    |--------------------------------------------------------------------------
+    */
+
+    protected $table = 'revisions';
+    protected $guarded = ['id'];
+
+    /*
+    |--------------------------------------------------------------------------
+    | RELATIONS
+    |--------------------------------------------------------------------------
+    */
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+    
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -59,6 +59,11 @@ class User extends Authenticatable
         return $this->hasMany(UserFeedback::class);
     }
 
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(Revision::class);
+    }
+
     public function isAdmin()
     {
         return $this->hasAnyRole('Site Admin');

--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -187,7 +187,6 @@ async function save(nextAction) {
 
     emit('update_rating', props.principleAssessment)
 
-    await axios.patch(`/principle-assessment/${props.principleAssessment.id}`, props.principleAssessment)
     let url = `/principle-assessment/${props.principleAssessment.id}`
 
     // check if we are saving a principle-assessment or additional-criteria-assessment
@@ -195,7 +194,7 @@ async function save(nextAction) {
         url = `/additional-assessment/${props.principleAssessment.id}`
     }
 
-        const res = await axios.patch(url, props.principleAssessment)
+    const res = await axios.patch(url, props.principleAssessment)
 
     emit(nextAction)
 

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -139,3 +139,4 @@ E.g., Centralise instituion selection to a single feature instead of distributin
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('institution-type') }}"><i class="nav-icon la la-question"></i> Institution types</a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('user-feedback') }}"><i class="nav-icon la la-question"></i> User feedback</a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('feedback-type') }}"><i class="nav-icon la la-question"></i> Feedback types</a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('revision') }}"><i class="nav-icon la la-question"></i> Revisions</a></li>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\Admin\RoleInviteCrudController;
 use App\Http\Controllers\Admin\ScoreTagCrudController;
 use App\Http\Controllers\Admin\UserCrudController;
 use App\Http\Controllers\Admin\UserFeedbackCrudController;
+use App\Http\Controllers\Admin\RevisionCrudController;
 use App\Http\Controllers\AssessmentController;
 use App\Http\Controllers\GeneratePdfFileController;
 use App\Http\Controllers\GenericDashboardController;
@@ -154,8 +155,8 @@ Route::group([
     Route::post('user-feedback', [UserFeedbackController::class, 'store']);
     Route::crud('feedback-type', UserFeedbackTypeCrudController::class);
 
+    Route::crud('revision', RevisionCrudController::class);
 });
-
 Route::get('project/{id}/show-as-pdf', [ProjectCrudController::class, 'show'])
     ->middleware('auth.basic')
     ->name('project.show-as-pdf');


### PR DESCRIPTION
This PR fixes #148 .

Note: This PR is not fully functioning yet. This is submitted as a progress update.

It provides a Revision CRUD panel. It is accessible via url now. (/admin/revision)
I will add it to sidebar for site admin and site manager in another PR.

As revision CRUD panel users (site admin and site manager) will not change anything in revision records. This CRUD panel is ready-only.

---

It shows below changes of user selected institution:
1. Institution ID (show for testing purpose temporary, will be removed soon)
2. Initiative name
3. Item type: Red Flag / Principle / Additional Criteria
4. Item: The name of corresponding Red Flag / Principle / Additional Criteria
5. Key: Which value has been changed. e.g. Red flag value / Principle rating / Principle is_na / Additional criteria rating / Additional criteria is_na
6. Old value: The original value before change
7. New value: The new value after change
8. User: User name made this change
9. Created: When did the change happen

---

TODO Items:
1. To determine whether we should provide "Search" feature. If so, what fields will be searched for?
2. Add a filter for initiatives, show revisions records of selected initiative only
3. Show revisions records that belong to user selected institution only (not sure how to achieve this, can we use global scope?)

---

Screen shot:

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/d6a1171c-305c-4bfb-9f66-cf2ebbe240e7)
