### PR TITLE
(MINOR) Fix the db seeders after portfolio database structure change

### DIFF
--- a/database/factories/PortfolioFactory.php
+++ b/database/factories/PortfolioFactory.php
@@ -18,8 +18,8 @@ class PortfolioFactory extends Factory
             'name' => $this->faker->catchPhrase(),
             'organisation_id' => Organisation::factory(),
             'budget' => $this->faker->randomNumber(),
+            'description' => $this->faker->paragraph,
             'currency' => $this->faker->currencyCode(),
-            'geographic_reach' => $this->faker->randomElement(GeographicalReach::cases()),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ];


### PR DESCRIPTION
1 line change to update the database seeder based on the portfolio table structure change. FIxes issue when running `migrate:fresh`. 