### PR TITLE
Add visuals to represent NA principles

### DIFF
--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -125,7 +125,7 @@ BEGIN
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = pr.project_id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN country_project cp');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = cp.project_id');
-    SET @SQLText = CONCAT(@SQLText, ' WHERE p.id = p.id');
+    SET @SQLText = CONCAT(@SQLText, ' WHERE p.deleted_at IS NULL');
 
 
     -- criteria
@@ -200,7 +200,7 @@ BEGIN
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = pr.project_id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN country_project cp');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = cp.project_id');
-    SET @SQLText = CONCAT(@SQLText, ' WHERE p.id = p.id');
+    SET @SQLText = CONCAT(@SQLText, ' WHERE p.deleted_at IS NULL');
 
 
     -- criteria

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -525,6 +525,8 @@ function getChartData(principlesSummary, nas) {
     return {
         labels: principlesSummary.map(item => item.name),
         datasets: [
+            // add fake, transparent datasets onto the yNa axis above the real NA line. This pushes the NA line down so that it sits underneath the principle name.
+            // without these, the NA line will be centered in the axis and overlap with the label.
             {
                 backgroundColor: 'transparent',
                 data: nas.map(item => 0),

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -349,12 +349,21 @@
                         <div class="col-12 col-lg-6 d-flex flex-column align-items-center">
                             <h2 class="mb-4">Your Initiatives</h2>
                             <Bar :data="chartDataYours" :options="chartOptions"/>
+                            <div class="text-center mt-4 px-4">
+                                <h5 class="mb-0">Percentage of Initiatives scoring at different levels by principle</h5>
+                                <p>Calculated using the number of initiatives for which the principle applied as the denominator.</p>
+                                <p>The grey lines under the name of the principle represent the % of initiatives that marked that principle as non-applicable </p>
+                            </div>
                         </div>
 
                         <div class="col-12 col-lg-6 d-flex flex-column align-items-center">
                             <h2 class="mb-4">Other Institutions' Initiatives</h2>
                             <Bar v-if="!summary.tooFewOtherProjects" :data="chartDataOthers" :options="chartOptions"/>
-
+                            <div v-if="!summary.tooFewOtherProjects" class="text-center mt-4 px-4">
+                                <h5 class="mb-0">Percentage of Initiatives scoring at different levels by principle</h5>
+                                <p>Calculated using the number of initiatives for which the principle applied as the denominator.</p>
+                                <p>The grey lines under the name of the principle represent the % of initiatives that marked that principle as non-applicable </p>
+                            </div>
                             <div v-else class="d-flex flex-column justify-content-center h-100">
                                 <div class="alert alert-info text-dark">There are too few initiatives or institutions
                                     within the current set of filters to display anonymized results.
@@ -379,7 +388,7 @@ import '@vuepic/vue-datepicker/dist/main.css'
 import {ref, computed, onMounted, watch} from "vue";
 import {isNumber} from "lodash";
 
-const tab = ref('summary')
+const tab = ref('principles')
 
 const props = defineProps({
     user: {
@@ -458,7 +467,7 @@ const anyFilters = computed(() => {
 
 function resetFilters() {
     Object.keys(filters.value).forEach(key => {
-        if(key!=="portfolio") filters.value[key] = null
+        if (key !== "portfolio") filters.value[key] = null
     });
     getData()
 }
@@ -511,24 +520,60 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 
 // ChartJS.register(ChartDataLabels);
 
-function getChartData(principlesSummary) {
+function getChartData(principlesSummary, nas) {
+
+    // nas = nas
+    //     .map(item => [item, item])
+    //     .flat()
+    //
+    // console.log(nas);
+
     return {
         labels: principlesSummary.map(item => item.name),
         datasets: [
             {
+                backgroundColor: 'transparent',
+                data: nas.map(item => 0),
+                stack: 'another-one',
+                grouped: true,
+                yAxisID: 'yNa',
+            },
+            {
+                label: 'NA',
+                backgroundColor: '#bbb',
+                data: nas.map(item => item.value),
+                barThickness: 4,
+                stack: 'na',
+                grouped: true,
+                yAxisID: 'yNa',
+                legend: false,
+            },
+            {
                 label: 'EXCELLENT (1.5 - 2.0)',
                 backgroundColor: '#54C45E',
-                data: principlesSummary.map(item => item.green)
+                data: principlesSummary.map(item => item.green),
+                barPercentage: 1,
+                categoryPercentage: 1,
+                stack: 'main',
+                grouped: true,
             },
             {
                 label: 'OK (0.5 - 1.5)',
                 backgroundColor: '#FFE342',
-                data: principlesSummary.map(item => item.yellow)
+                data: principlesSummary.map(item => item.yellow),
+                barPercentage: 1,
+                categoryPercentage: 1,
+                stack: 'main',
+                grouped: true,
             },
             {
                 label: 'POOR (0.0 - 0.5)',
                 backgroundColor: '#e3342f',
-                data: principlesSummary.map(item => item.red)
+                data: principlesSummary.map(item => item.red),
+                barPercentage: 1,
+                categoryPercentage: 1,
+                stack: 'main',
+                grouped: true,
             },
         ]
     }
@@ -537,7 +582,7 @@ function getChartData(principlesSummary) {
 const chartDataYours = computed(() => {
 
     if (summary.value.yoursPrinciplesSummarySorted) {
-        return getChartData(summary.value.yoursPrinciplesSummarySorted)
+        return getChartData(summary.value.yoursPrinciplesSummarySorted, summary.value.yourNas)
     }
     return {
         labels: [],
@@ -548,7 +593,7 @@ const chartDataYours = computed(() => {
 const chartDataOthers = computed(() => {
 
     if (summary.value.othersPrinciplesSummarySorted && !summary.value.tooFewOtherProjects) {
-        return getChartData(summary.value.othersPrinciplesSummarySorted)
+        return getChartData(summary.value.othersPrinciplesSummarySorted, summary.value.otherNas)
     }
     return {
         labels: [],
@@ -564,9 +609,10 @@ const chartOptions = ref({
     scales: {
         y: {
             stacked: true,
-
             ticks: {
+                min: 50,
                 mirror: true,
+                align: 'end',
                 z: 1,
                 color: 'black',
                 font: {
@@ -578,21 +624,13 @@ const chartOptions = ref({
             stacked: true,
             max: 100,
         },
+        yNa: {
+            display: false,
+            stacked: false,
+            max: 100,
+        },
     },
     plugins: {
-        // datalabels: {
-        //     color: 'black',
-        //     display: function (context) {
-        //         return context.dataset.data[context.dataIndex] > 10; // hide label if bar is too short
-        //     },
-        //     font: {
-        //         weight: 'bold'
-        //     },
-        //     formatter: function (value, context) {
-        //         return Math.round(value) + "%"
-        //     }
-        // },
-
         tooltip: {
             padding: 14,
             backgroundColor: '#f8f9fa',
@@ -610,13 +648,20 @@ const chartOptions = ref({
                 label: (context) => context.formattedValue,
             },
         },
+        legend: {
+            labels: {
+                // filter out the first dataset label (that dataset is purely to move the 'na' line down slightly)
+                filter: function (item, chart) {
+                    return item.datasetIndex > 0
+                }
+            }
+        }
     },
     barPercentage: 1,
     categoryPercentage: 1,
     barThickness: 'flex',
     borderWidth: 1,
     borderColor: 'lightgrey',
-
 })
 
 </script>

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -522,15 +522,30 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 
 function getChartData(principlesSummary, nas) {
 
-    // nas = nas
-    //     .map(item => [item, item])
-    //     .flat()
-    //
-    // console.log(nas);
-
     return {
         labels: principlesSummary.map(item => item.name),
         datasets: [
+            {
+                backgroundColor: 'transparent',
+                data: nas.map(item => 0),
+                stack: 'another-one',
+                grouped: true,
+                yAxisID: 'yNa',
+            },
+            {
+                backgroundColor: 'transparent',
+                data: nas.map(item => 0),
+                stack: 'another-one',
+                grouped: true,
+                yAxisID: 'yNa',
+            },
+            {
+                backgroundColor: 'transparent',
+                data: nas.map(item => 0),
+                stack: 'another-one',
+                grouped: true,
+                yAxisID: 'yNa',
+            },
             {
                 backgroundColor: 'transparent',
                 data: nas.map(item => 0),
@@ -652,7 +667,7 @@ const chartOptions = ref({
             labels: {
                 // filter out the first dataset label (that dataset is purely to move the 'na' line down slightly)
                 filter: function (item, chart) {
-                    return item.datasetIndex > 0
+                    return item.datasetIndex > 3
                 }
             }
         }

--- a/resources/js/radarChart.js
+++ b/resources/js/radarChart.js
@@ -12,7 +12,6 @@ console.log('spider');
 
 window.spiderChart = function SpiderChart(id, data, options) {
 
-    console.log('data', data);
     var cfg = {
 	 w: 600,				//Width of the circle
 	 h: 600,				//Height of the circle
@@ -137,6 +136,7 @@ window.spiderChart = function SpiderChart(id, data, options) {
 		.attr("x", function(d, i){ return rScale(maxValue * cfg.labelFactor) * Math.cos(angleSlice*i - Math.PI/2); })
 		.attr("y", function(d, i){ return rScale(maxValue * cfg.labelFactor) * Math.sin(angleSlice*i - Math.PI/2); })
 		.text(function(d){return d.axis})
+        // if value is null, make the label grey (to highlight 'na' values)
         .attr("fill", function(d){return d.value ? "#000" : "#919191"})
 		.call(wrap, cfg.wrapWidth);
 

--- a/resources/js/radarChart.js
+++ b/resources/js/radarChart.js
@@ -11,7 +11,9 @@
 console.log('spider');
 
 window.spiderChart = function SpiderChart(id, data, options) {
-	var cfg = {
+
+    console.log('data', data);
+    var cfg = {
 	 w: 600,				//Width of the circle
 	 h: 600,				//Height of the circle
 	 margin: {top: 20, right: 20, bottom: 20, left: 20}, //The margins of the SVG
@@ -112,7 +114,7 @@ window.spiderChart = function SpiderChart(id, data, options) {
 
 	//Create the straight lines radiating outward from the center
 	var axis = axisGrid.selectAll(".axis")
-		.data(allAxis)
+		.data(data[0])
 		.enter()
 		.append("g")
 		.attr("class", "axis");
@@ -134,7 +136,8 @@ window.spiderChart = function SpiderChart(id, data, options) {
 		.attr("dy", "0.35em")
 		.attr("x", function(d, i){ return rScale(maxValue * cfg.labelFactor) * Math.cos(angleSlice*i - Math.PI/2); })
 		.attr("y", function(d, i){ return rScale(maxValue * cfg.labelFactor) * Math.sin(angleSlice*i - Math.PI/2); })
-		.text(function(d){return d})
+		.text(function(d){return d.axis})
+        .attr("fill", function(d){return d.value ? "#000" : "#919191"})
 		.call(wrap, cfg.wrapWidth);
 
 	/////////////////////////////////////////////////////////

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -96,14 +96,26 @@
                 </table>
             </div>
 
-            <div class="col-12 col-lg-6 print-8 d-flex justify-content-center align-items-center">
+            <div class="col-12 col-lg-6 print-8 d-flex justify-content-top align-items-center flex-column">
                 @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value && $entry->latest_assessment->redline_status !== \App\Enums\AssessmentStatus::Failed->value)
-                    <div id="radarChart"></div>
+                    <div id="radarChart" class="w-100"></div>
+
+                    @if($entry->latest_assessment->principleAssessments->pluck('is_na')->contains(1))
+                        <div class="mt-4">
+                            <h6 class="font-weight-bold">Principles Not Applicable for this Initiative:</h6>
+                            <ul>
+                                @foreach($entry->latest_assessment->principleAssessments->where('is_na', 1) as $principleAssessment)
+                                    <li>{{ $principleAssessment->principle->name }}</li>
+                                @endforeach
+                            </ul>
+                    @endif
+
                 @elseif($entry->latest_assessment->redline_status === \App\Enums\AssessmentStatus::Failed->value)
                     <p class="text-center text-secondary">~~ Red flag assessment failed ~~<br/>~~ no principle assessment results available ~~</p>
                 @else
                     <p class="text-center text-secondary">~~ Principle assessment not completed ~~<br/>~~ no results available ~~</p>
                 @endif
+
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
This PR addresses an issue highlighted by Emile, where there is no visual indication of principles that were marked as NA. 

Currently, 
- in the Initiative Show page, an "na" cannot be differentiated from a '0' in the spider chart, which is incorrect.
- in the Dashboard principles chart, there is no indication of how many initiatives marked a principle as "na". So one principle's summary might be based on 50 initiatives, while the next principle is based on 40 initiatives, and there is no visual to indicate this difference. 

Carlos suggested an improvement for the dashboard in the attached - adding a thin grey bar over the top of the main block colours for each principle to show the % of initiatives that marked the item as NA. This PR adds those bars, along with a description below the graphic. 

The PR also updates the spider chart on the initiative show page to grey out the items marked as NA. 

[Suggestion for summary of initiatives.pptx](https://github.com/stats4sd/aec_portfolio/files/12241012/Suggestion.for.summary.of.initiatives.pptx)

This PR doesn't address the 3rd slide, that includes suggested updates to the text / way of explaining the total rating for individual initiatives. We'll include that in a broader 'documentation / guides' PR. 