### PR TITLE
Budget checks

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -57,9 +57,12 @@ Project extends Model
 
         static::saved(function (Project $project) {
 
+            // refresh from the database in case the exchange_rate was set by SQL default;
+            $project->refresh();
             // in case the exchange_rate has changed, re-calculate the budget_org
            $project->budget_org = $project->budget * $project->exchange_rate;
            $project->saveQuietly();
+            ddd($project);
         });
 
         static::addGlobalScope('organisation', function (Builder $builder) {

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -62,7 +62,6 @@ Project extends Model
             // in case the exchange_rate has changed, re-calculate the budget_org
            $project->budget_org = $project->budget * $project->exchange_rate;
            $project->saveQuietly();
-            ddd($project);
         });
 
         static::addGlobalScope('organisation', function (Builder $builder) {

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -57,8 +57,6 @@ Project extends Model
 
         static::saved(function (Project $project) {
 
-            // refresh from the database in case the exchange_rate was set by SQL default;
-            $project->refresh();
             // in case the exchange_rate has changed, re-calculate the budget_org
            $project->budget_org = $project->budget * $project->exchange_rate;
            $project->saveQuietly();

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -34,6 +34,7 @@ class ProjectFactory extends Factory
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
             'currency' => $this->faker->currencyCode(),
+            'exchange_rate' => $this->faker->numberBetween(1, 20) / 10,
             'start_date' => Carbon::now(),
             'end_date' => Carbon::now(),
             'geographic_reach' => $this->faker->randomElement(GeographicalReach::cases()),

--- a/database/seeders/ProjectSeeder.php
+++ b/database/seeders/ProjectSeeder.php
@@ -63,6 +63,8 @@ class ProjectSeeder extends Seeder
         // add complete assessments for projects
         foreach (Project::withoutGlobalScopes()->get() as $project) {
 
+            // save the project to calculate budget_org
+
             // assign 80% of projects to regions
             if ($this->faker->boolean(80)) {
                 $project->regions()->sync($this->faker->randomElements(

--- a/public/assets/js/admin/forms/project_create.js
+++ b/public/assets/js/admin/forms/project_create.js
@@ -5,7 +5,8 @@ exchangeRateField = crud.field('exchange_rate')
 
 crud.field('currency').onChange(function(field) {
     crud.field('get_exchange_rate_button').hide(field.value.toUpperCase() == orgCurrencyField.value).disable(field.value.toUpperCase() == orgCurrencyField.value);
-    crud.field('exchange_rate').hide(field.value.toUpperCase() == orgCurrencyField.value).disable(field.value.toUpperCase() == orgCurrencyField.value);
+    crud.field('exchange_rate').hide(field.value.toUpperCase() == orgCurrencyField.value)
+    crud.field('exchange_rate').input.value = 1;
   }).change();
 
 async function getConversionRatio(baseCurrency, currency, date) {

--- a/public/assets/js/admin/forms/project_create.js
+++ b/public/assets/js/admin/forms/project_create.js
@@ -3,11 +3,15 @@ orgCurrencyField = crud.field('org_currency')
 startDateField = crud.field('start_date')
 exchangeRateField = crud.field('exchange_rate')
 
-crud.field('currency').onChange(function(field) {
+crud.field('currency').onChange(function (field) {
+
     crud.field('get_exchange_rate_button').hide(field.value.toUpperCase() == orgCurrencyField.value).disable(field.value.toUpperCase() == orgCurrencyField.value);
     crud.field('exchange_rate').hide(field.value.toUpperCase() == orgCurrencyField.value)
-    crud.field('exchange_rate').input.value = 1;
-  }).change();
+
+    if (field.value.toUpperCase() == orgCurrencyField.value) {
+        crud.field('exchange_rate').input.value = 1;
+    }
+}).change();
 
 async function getConversionRatio(baseCurrency, currency, date) {
 


### PR DESCRIPTION
This PR fixes #198, fixes #191.

### budget_org not saved

When an initiative's currency is the same as the organisation's default, the exchange_rate entry field is hidden, and instead the exchange_rate is set to 1. This was being done at the database level. This meant that the PHP code to calculate the budget_org field did not have that information, and so was multiplying by null. 

This PR fixes that to always send a value for the exchange rate through the CRUD panel when creating or editing a project, so that the budget_org calculation runs correctly. 

### sort by budget on the initiatives page. 
Turns out the sorting wasn't actually working at all, as it was sorting `initiatives` instead of `filteredInitiatives`. This PR fixes that issue, and also sets the budget sorting to work with `budget_org` instead of `budget` (as `budget` may be in different currencies, so the absolute values aren't directly comparable for sorting). 

