### PR TITLE
Bug fix to avoid generating a duplicated initiative code

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -35,7 +35,9 @@ Project extends Model
     {
         static::creating(function ($project) {
             if (is_null($project->code)) {
-                $org_project_number = Project::where('organisation_id', $project->organisation_id)->count() + 1;
+                // when counting total number of project of an organisation, include soft-deleted projects
+                // to avoid generating a duplicated project code
+                $org_project_number = Project::withTrashed()->where('organisation_id', $project->organisation_id)->count() + 1;
 
                 $org_name = $project->organisation->name;
                 $org_name_words = explode(' ', $org_name);


### PR DESCRIPTION
This PR is submitted as a bug fix to avoid generating a duplicated initiative code.

Soft-deleted initaitves was not counted when generating an initiative code, which check for the total number of initiatives of an institution.

Currently it does not count the soft-deleted initiatives. A duplicated initiative code can be generated when creating new initiative. The initiative can be created without any issue. When user edit an initiative, it will not allow user to save because there is another initiative with same initiative code.

The solution is to include soft-deleted initiative when counting total number of initiatives of an institution. Suppose initiative records will not be permanently deleted in database, the latest program should be able to generate unique initative code (per institution).

---

Screen shot of database table projects

Delete an initiative in front end, then create a new initative
Both initiative has same initiative code...

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/1a8782b0-07f7-4e49-a87a-54ad4a877c4a)
