### PR TITLE
Adds Help Text Helper + Guidance throughout system

### DIFF
--- a/app/Http/Controllers/Admin/HelpTextEntryCrudController.php
+++ b/app/Http/Controllers/Admin/HelpTextEntryCrudController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Requests\HelpTextItemRequest;
+use App\Models\HelpTextEntry;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+use Backpack\CRUD\app\Library\Widget;
+
+/**
+ * Class HelpTextItemCrudController
+ * @package App\Http\Controllers\Admin
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class HelpTextEntryCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+
+    /**
+     * Configure the CrudPanel object. Apply settings to all operations.
+     *
+     * @return void
+     */
+    public function setup()
+    {
+        CRUD::setModel(\App\Models\HelpTextEntry::class);
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/help-text-entry');
+        CRUD::setEntityNameStrings('help text entries', 'help text entries');
+
+        if(auth()->user()->cannot('manage help text entries')) {
+            CRUD::denyAccess(['list', 'update']);
+        }
+
+    }
+
+    /**
+     * Define what happens when the List operation is loaded.
+     *
+     * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
+     * @return void
+     */
+    protected function setupListOperation()
+    {
+        Widget::add()
+            ->to('before_content')
+            ->type('card')
+            ->wrapper('col-10')
+            ->content([
+                'body' => 'This page allows you to review and update the helper text available throughout the platform. All the text available via the ? symbols can be updated below. Only the text can be changed - there is no way to add additional help text entries through this system.'
+            ]);
+
+        CRUD::column('name');
+        CRUD::column('text');
+    }
+
+    /**
+     * Define what happens when the Create operation is loaded.
+     *
+     * @see https://backpackforlaravel.com/docs/crud-operation-create
+     * @return void
+     */
+    protected function setupCreateOperation()
+    {
+        CRUD::field('info')
+            ->type('section-title')
+            ->title('Edit Help Text')
+            ->content('Use the form below to edit the help text. The location below is the page and position that this text will appear to users of the platform')
+            ->view_namespace('stats4sd.laravel-backpack-section-title::fields');
+
+        CRUD::field('location')->attributes(['disabled' => 'disabled', 'readonly' => 'readonly']);
+        CRUD::field('text')->type('summernote');
+    }
+
+    /**
+     * Define what happens when the Update operation is loaded.
+     *
+     * @see https://backpackforlaravel.com/docs/crud-operation-update
+     * @return void
+     */
+    protected function setupUpdateOperation()
+    {
+        $this->setupCreateOperation();
+    }
+
+
+    // helper class to return the correct help text for use in a vue component.
+    public function find(string $location)
+    {
+        return HelpTextEntry::firstWhere('location', $location);
+    }
+}

--- a/app/Http/Controllers/Admin/HelpTextEntryCrudController.php
+++ b/app/Http/Controllers/Admin/HelpTextEntryCrudController.php
@@ -43,16 +43,21 @@ class HelpTextEntryCrudController extends CrudController
      */
     protected function setupListOperation()
     {
+        CRUD::setDefaultPageLength(25);
+        CRUD::setResponsiveTable(false);
+
         Widget::add()
             ->to('before_content')
             ->type('card')
-            ->wrapper('col-10')
+            ->wrapper([
+                'class' => 'col-10',
+                ])
             ->content([
-                'body' => 'This page allows you to review and update the helper text available throughout the platform. All the text available via the ? symbols can be updated below. Only the text can be changed - there is no way to add additional help text entries through this system.'
+                'body' => 'This page allows you to review and update the helper text available throughout the platform. All the text available via the ? symbols can be updated below. Only the text can be changed - there is no way to add additional help text entries through this system.',
             ]);
 
-        CRUD::column('name');
-        CRUD::column('text');
+        CRUD::column('location');
+        CRUD::column('text')->limit(100);
     }
 
     /**

--- a/app/Models/HelpTextEntry.php
+++ b/app/Models/HelpTextEntry.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class HelpTextEntry extends Model
+{
+    use CrudTrait;
+
+    protected $table = 'help_text_entries';
+    protected $guarded = ['id'];
+
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Observers\RoleInviteObserver;
 use App\Observers\OrganisationObserver;
 use App\Observers\UserObserver;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 

--- a/app/View/Components/HelpTextEntry.php
+++ b/app/View/Components/HelpTextEntry.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class HelpTextEntry extends Component
+{
+
+    public \App\Models\HelpTextEntry $helpTextEntry;
+
+    public function __construct(
+        public string $sectionId,
+        public string $location,
+    )
+    {
+        $this->helpTextEntry = \App\Models\HelpTextEntry::firstWhere('location', $location);
+    }
+
+    public function render(): View
+    {
+        return view('components.help-text-entry');
+    }
+}

--- a/app/View/Components/HelpTextEntry.php
+++ b/app/View/Components/HelpTextEntry.php
@@ -11,7 +11,6 @@ class HelpTextEntry extends Component
     public \App\Models\HelpTextEntry $helpTextEntry;
 
     public function __construct(
-        public string $sectionId,
         public string $location,
     )
     {

--- a/database/migrations/2023_08_04_113912_create_help_text_entries_table.php
+++ b/database/migrations/2023_08_04_113912_create_help_text_entries_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('help_text_entries', function (Blueprint $table) {
+            $table->id();
+            $table->string('location');
+            $table->text('text');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('help_text_entries');
+    }
+};

--- a/database/seeders/HelpTextEntrySeeder.php
+++ b/database/seeders/HelpTextEntrySeeder.php
@@ -59,6 +59,15 @@ class HelpTextEntrySeeder extends Seeder
                     ",
             ],
             [
+                'location' => 'Initiatives - score',
+                'text' => "
+                    The overall score for the initiative is calculated as follows: <ul>
+                        <li>The sum of the rating given for each principle, divided by the maximum possible score.</li>
+                        <li>The maximum score is 2 per principle. It takes into account any principles marked as NA. For example, an initiative where all 13 principles are relevant will be marked out of 13 x 2 = 26. If 2 principles are marked as NA, the initiative will be marked out of 11 x 2 = 22.</li>
+</ul>
+                    ",
+            ],
+            [
                 'location' => 'Dashboard - page title',
                 'text' => "
                     This page presents an overall summary of your institution's initiatives and compares your assessment results against the results from other institutions that use this tool. You can navigate the tabs below to review a summary of your overall portfolio ('Summary of Initaitives'), and the results of each step of the main assessment ('Summary of Red Flags' and 'Summary of Principles'). See the help text on each tab for more information.<br/><br/>
@@ -113,7 +122,7 @@ class HelpTextEntrySeeder extends Seeder
             ],
         ];
 
-        foreach($helpTextEntries as $helpTextEntry) {
+        foreach ($helpTextEntries as $helpTextEntry) {
             HelpTextEntry::create($helpTextEntry);
         }
     }

--- a/database/seeders/HelpTextEntrySeeder.php
+++ b/database/seeders/HelpTextEntrySeeder.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\HelpTextEntry;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class HelpTextEntrySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        HelpTextEntry::destroy(HelpTextEntry::all()->pluck('id')->toArray());
+
+        $helpTextEntries = [
+            [
+                'location' => 'My Institution - page title',
+                'text' => 'This is the default landing page for users linked to your institution. Below, you can see the key information related to your institution, including the list of users, the portfolios of initiatives to be assessed, and a page of settings. See the information in the tabs below for more details. <br/><br/> If you are a member of multiple institutions, you can change institution using the link in the top-right of the page.',
+            ],
+            [
+                'location' => 'My Institution - Institution members',
+                'text' => "
+                       There are 3 types of user within an institution.
+                       <ul>
+                        <li><b>Institutional Admin:</b> Admins have full control over the institution. They can invite new users, change the institution's settings and export or delete all data belonging to the institution from the platform.</li>
+                        <li><b>Institutional Assessor:</b> Assessors can create, edit and delete initiatives and portfolios. They have full authority to perform assessments of initiatives for the institution.</li>
+                        <li><b>Institutional Member:</b> A regular member has read-only access to the platform. They can view all the initiatives and results of assessments, and they can access the Dashboard to review the overall institutional performance compared with other institutions within the system.</li>
+                        </ul>
+
+                        Institutional Admins may use this page to invite new users and manage existing users, which includes the ability to change the role of a user.
+
+
+                ",
+            ],
+            [
+                'location' => 'My Institution - Portfolios',
+                'text' => "Every institution needs at least one portfolio. A portfolio is a set of initiatives, but beyond that we have deliberately left the definition of a portfolio broad, so it can fit your institution's existing method of grouping initiatives. For smaller institutions with only a few initiatives, you can choose to have 1 single portfolio if you wish.",
+            ],
+            [
+                'location' => 'My Institution - Details',
+                'text' => "
+                       The only required information for your institution is the name (for identification), and the default currency. The currency is used to convert initiative budgets into a single currency for display on the dashboard.<br/><br/>
+                       Optionally, an institutional admin may add extra information below. The 'institution type', geographic reach and HQ country will be useful for future analysis of anonymized analysis results by the Agroecology Coalition. ",
+            ],
+            [
+                'location' => 'Initiatives - List page',
+                'text' => "
+                    This page presents the initiatives entered into the platform by your institution, and provides the links to conduct the assessment. You can use the filters and search features to find a given initiative. The page presents 1 initiative per card in the list below. You can see more options by clicking the blue arrow button on the right of any card.<br/><br/>
+                    Each initiative shows the current status of the assessment, and presents the 'next' action as the main green button on the card. In the expanded section, you may also edit any previously completed section of the assessment, or even choose to 'reassess' the entire initiative, which will reset the entire assessment for that initiative and allow you to start from the beginning.",
+            ],
+            [
+                'location' => 'Initiatives - statuses',
+                'text' => "
+                    The main initiative status is based on the overall assessment progress. It shows the latest 'step' in the process, and the status of that step.<br/><br/>
+                    In the expanded view, you will see the status for each individual step. You can also filter initiatives by the status of a specific step, for example you may wish to show all initiatives with 'Red flags - complete' and 'Principles - Not Started'.
+                    ",
+            ],
+            [
+                'location' => 'Dashboard - page title',
+                'text' => "
+                    This page presents an overall summary of your institution's initiatives and compares your assessment results against the results from other institutions that use this tool. You can navigate the tabs below to review a summary of your overall portfolio ('Summary of Initaitives'), and the results of each step of the main assessment ('Summary of Red Flags' and 'Summary of Principles'). See the help text on each tab for more information.<br/><br/>
+                    You may filter the results shown in 2 ways:
+                    <ul>
+                    <li>You may restrict the results to a single portfolio. In this case, 'your' results will be filtered to only the selected portfolio. The comparision against other institutions will remain unchanged./li>
+                    <li>You may add one or more filters based on the initiative properties, including location, category, date and budget. These filters will be applied to both your initiatives and initiatives from other institutions. For example, you can compare all your initiatives that started between 2020 and 2023 with all other institutions' initiatives from the same time period.</li>
+                    </ul>
+                ",
+            ],
+            [
+                'location' => 'Dashboard - initiatives added',
+                'text' => "The number of initiatives your institution has added that match the current set of filters.",
+            ],
+            [
+                'location' => 'Dashboard - passed all red flags',
+                'text' => "The number of initiatives that have completed and passed the red flag assessment.",
+            ],
+            [
+                'location' => 'Dashboard - fully assessed',
+                'text' => "The number of initiatives that have completed the full assessment. This means the initiative has either failed the red flags assessment, or passed the red flags and completed the principle assessment step.",
+            ],
+            [
+                'location' => 'Dashboard - overall score',
+                'text' => "
+                    The overall score is calculated as the average score of all fully assessed initiatives. Initiatives that failed the red flag assessment have a score of 0%. Other initiatives have a score calculated as follows:
+                    <ul><li>The sum of ratings for each principle, divided by the total possible score and expressed as a percentage.</li></ul>",
+            ],
+            [
+                'location' => 'Dashboard - AE focused budget',
+                'text' => "The Agroecology-focused budget is calculated as the total budget multipled by the overall score as a percentage. So if your overall score is 50%, the Agroecology-focused budget will be 1/2 of the total budget.",
+            ],
+            [
+                'location' => 'Dashboard - Redflags summary',
+                'text' => "
+                    The table below shows the summary of results from the red flags portion of the assessment. For each red flag, the table shows the % of your initiatives that passed, and the % of initiatives from other institutions that passed. The colours of the rows highlight the performance of your initiatives - green means 100% of your initiatives passed, and yellow shows where some % of your initiatives failed that red flag.
+                ",
+            ],
+            [
+                'location' => 'Dashboard - Summary of Principles',
+                'text' => "
+                    This tab presents a visual summary of your initiatives' performance in each of the 13 Principles of Agroecology. Each colour shows the % of initiatives that scored in a certain range for that principle.
+                    <ul>
+                    <li>The green bar is the % of initiatives that scored 1.5 or higher</li>
+                    <li>The yellow bar is the % of initiatives that scored between 0.5 and 1.5 or higher</li>
+                    <li>The red bar is the % of initiatives that scored lower than 0.5</li>
+                    </ul>
+                   The 3 coloured segments add up to 100% of the initiatives for which that principle applied.   <br/><br/>
+                   There is also a grey line under some of the principle names - this line represents the % of initiatives that marked the principle as 'not applicable' in the assessment. <br/><br/>
+                   You can hover over the graph to view the actual %s for each principle. You may also hide any of the categories by clicking on that category in the legend above the graph. For example, to view the graph without the grey 'na' line, you can click the grey square and 'NA' label. Click again to display it.
+                ",
+            ],
+        ];
+
+        foreach($helpTextEntries as $helpTextEntry) {
+            HelpTextEntry::create($helpTextEntry);
+        }
+    }
+}

--- a/database/seeders/HelpTextEntrySeeder.php
+++ b/database/seeders/HelpTextEntrySeeder.php
@@ -83,11 +83,11 @@ class HelpTextEntrySeeder extends Seeder
                 'text' => "The number of initiatives your institution has added that match the current set of filters.",
             ],
             [
-                'location' => 'Dashboard - passed all red flags',
+                'location' => 'Dashboard - Passed all red flags',
                 'text' => "The number of initiatives that have completed and passed the red flag assessment.",
             ],
             [
-                'location' => 'Dashboard - fully assessed',
+                'location' => 'Dashboard - Fully assessed',
                 'text' => "The number of initiatives that have completed the full assessment. This means the initiative has either failed the red flags assessment, or passed the red flags and completed the principle assessment step.",
             ],
             [

--- a/database/seeders/HelpTextEntrySeeder.php
+++ b/database/seeders/HelpTextEntrySeeder.php
@@ -73,7 +73,7 @@ class HelpTextEntrySeeder extends Seeder
                     This page presents an overall summary of your institution's initiatives and compares your assessment results against the results from other institutions that use this tool. You can navigate the tabs below to review a summary of your overall portfolio ('Summary of Initaitives'), and the results of each step of the main assessment ('Summary of Red Flags' and 'Summary of Principles'). See the help text on each tab for more information.<br/><br/>
                     You may filter the results shown in 2 ways:
                     <ul>
-                    <li>You may restrict the results to a single portfolio. In this case, 'your' results will be filtered to only the selected portfolio. The comparision against other institutions will remain unchanged./li>
+                    <li>You may restrict the results to a single portfolio. In this case, 'your' results will be filtered to only the selected portfolio. The comparision against other institutions will remain unchanged.</li>
                     <li>You may add one or more filters based on the initiative properties, including location, category, date and budget. These filters will be applied to both your initiatives and initiatives from other institutions. For example, you can compare all your initiatives that started between 2020 and 2023 with all other institutions' initiatives from the same time period.</li>
                     </ul>
                 ",

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -76,6 +76,7 @@ class RoleSeeder extends Seeder
         // extras
         Permission::updateOrCreate(['name' => 'edit own institution', 'guard_name' => 'web']);
         Permission::updateOrCreate(['name' => 'manage user feedback', 'guard_name' => 'web']);
+        Permission::updateOrCreate(['name' => 'manage help text entries', 'guard_name' => 'web']);
 
 
         // roles_has_permissions
@@ -126,6 +127,7 @@ class RoleSeeder extends Seeder
         $admin->givePermissionTo('maintain custom principles');
 
         $admin->givePermissionTo('manage user feedback');
+        $admin->givePermissionTo('manage help text entries');
 
 
         $manager->givePermissionTo('view red lines');
@@ -143,6 +145,7 @@ class RoleSeeder extends Seeder
         $manager->givePermissionTo('maintain custom principles');
         $manager->givePermissionTo('view institutional members');
         $manager->givePermissionTo('manage user feedback');
+        $manager->givePermissionTo('manage help text entries');
 
 
         $insAdmin->givePermissionTo('invite institutional members');

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "flot": "^4.2.3",
                 "noty": "^3.2.0-beta-deprecated",
                 "puppeteer": "^20.2.0",
+                "slugify": "^1.6.6",
                 "sweetalert2": "^11.7.12",
                 "vite-plugin-vuetify": "^1.0.2",
                 "vue": "^3.2.37",
@@ -3408,6 +3409,14 @@
             "dev": true,
             "dependencies": {
                 "less": "^3.12.2"
+            }
+        },
+        "node_modules/slugify": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+            "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/smart-buffer": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "flot": "^4.2.3",
         "noty": "^3.2.0-beta-deprecated",
         "puppeteer": "^20.2.0",
+        "slugify": "^1.6.6",
         "sweetalert2": "^11.7.12",
         "vite-plugin-vuetify": "^1.0.2",
         "vue": "^3.2.37",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,3 +9,7 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 window.swal = Swal;
 
 console.log('hi');
+
+$(function () {
+  $('[data-toggle="popover"]').popover()
+})

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,7 +8,6 @@ window.axios = axios;
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 window.swal = Swal;
 
-console.log('hi');
 
 $(function () {
   $('[data-toggle="popover"]').popover()

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -11,7 +11,9 @@
                     <h5 class="font-weight-bold text-bright-green">Current Assessment</h5>
                     <div class="d-flex justify-content-between">
                         <div class="w-50">
-                            <span class="font-weight-bold text-grey">STATUS</span><br/>
+                            <span class="font-weight-bold text-grey">STATUS</span>
+                            <v-help-text-link location="Initiatives - statuses" type="popover"/>
+                            <br/>
                             <span class="font-weight-bold">{{ initiative.latest_assessment.assessment_status }}</span>
                         </div>
                         <div class="w-50">
@@ -136,6 +138,7 @@
 
 import {computed, defineEmits, ref} from "vue";
 import Swal from "sweetalert2";
+import VHelpTextLink from "./vHelpTextLink.vue";
 
 const props = defineProps({
     initiative: Object,

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -17,11 +17,14 @@
                             <span class="font-weight-bold">{{ initiative.latest_assessment.assessment_status }}</span>
                         </div>
                         <div class="w-50">
-                            <span class="font-weight-bold text-grey">SCORE</span><br/>
+                            <span class="font-weight-bold text-grey">SCORE</span>
+                            <v-help-text-link location="Initiatives - score" type="popover"/>
+                            <br/>
                             <span class="font-xl text-bright-green font-weight-bold"
                                   v-if="initiative.latest_assessment.overall_score !== null">{{
                                     initiative.latest_assessment.overall_score
                                 }}%</span>
+
                         </div>
                     </div>
                 </div>

--- a/resources/js/components/InitiativesList.vue
+++ b/resources/js/components/InitiativesList.vue
@@ -1,10 +1,14 @@
 <template>
 
-    <div class="d-flex justify-content-between align-items-center mb-4">
+    <div class="d-flex justify-content-start align-items-center mb-4">
         <h1 class="font-weight-bold text-deep-green my-0">
             {{ organisation.name }} - Initiatives
         </h1>
+        <v-help-text-link class="font-2xl" location="Initiatives - List page"/>
     </div>
+
+    <v-help-text-entry class="mb-4" location="Initiatives - List page"/>
+
     <!-- filters -->
     <div class="d-flex justify-content-between flex-column flex-lg-row">
         <div class="d-flex flex-column mb-0 w-100">
@@ -100,6 +104,8 @@ import vSelect from 'vue-select'
 import {computed, ref, watch, onMounted} from "vue";
 import InitiativeListCard from "./InitiativeListCard.vue";
 import {watchDebounced} from "@vueuse/core";
+import VHelpTextLink from "./vHelpTextLink.vue";
+import VHelpTextEntry from "./vHelpTextEntry.vue";
 
 
 const props = defineProps({

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -3,11 +3,11 @@
 
         <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Details</h2>
-        <v-help-text-link class="font-2xl" section-id="#details-help"/>
+        <v-help-text-link class="font-2xl" location="My Institution - Portfolios"/>
     </div>
         <p class="help-block">Add or edit the relevant information for the institution.</p>
 
-        <v-help-text-entry section-id="details-help" location="My Institution - Portfolios"/>
+        <v-help-text-entry location="My Institution - Portfolios"/>
 
 
     </div>

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -3,11 +3,11 @@
 
         <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Details</h2>
-        <v-help-text-link class="font-2xl" location="My Institution - Settings"/>
+        <v-help-text-link class="font-2xl" location="My Institution - Details"/>
     </div>
         <p class="help-block">Add or edit the relevant information for the institution.</p>
 
-        <v-help-text-entry location="My Institution - Settings"/>
+        <v-help-text-entry location="My Institution - Details"/>
 
 
     </div>

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -3,11 +3,11 @@
 
         <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Details</h2>
-        <v-help-text-link class="font-2xl" location="My Institution - Portfolios"/>
+        <v-help-text-link class="font-2xl" location="My Institution - Settings"/>
     </div>
         <p class="help-block">Add or edit the relevant information for the institution.</p>
 
-        <v-help-text-entry location="My Institution - Portfolios"/>
+        <v-help-text-entry location="My Institution - Settings"/>
 
 
     </div>

--- a/resources/js/components/InstitutionSettings.vue
+++ b/resources/js/components/InstitutionSettings.vue
@@ -1,8 +1,15 @@
 <template>
     <div class="card-header">
 
-        <h2>Institution Details</h2>
+        <div class="d-flex align-items-center">
+        <h2 class="mb-0">Institution Details</h2>
+        <v-help-text-link class="font-2xl" section-id="#details-help"/>
+    </div>
         <p class="help-block">Add or edit the relevant information for the institution.</p>
+
+        <v-help-text-entry section-id="details-help" location="My Institution - Portfolios"/>
+
+
     </div>
 
     <div class="card-body">
@@ -165,6 +172,8 @@
 import {onMounted, ref, computed} from "vue";
 import 'vue-select/dist/vue-select.css';
 import vSelect from 'vue-select'
+import VHelpTextEntry from "./vHelpTextEntry.vue";
+import VHelpTextLink from "./vHelpTextLink.vue";
 
 
 const props = defineProps({

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -243,11 +243,13 @@
                                 </li>
                                 <li
                                     v-for="summaryLine in summary.statusSummary"
-                                    class="list-group-item d-flex font-lg text-deep-green">
+                                    class="list-group-item d-flex font-lg text-deep-green align-items-center">
                                     <span class="w-50 text-right pr-4">{{ summaryLine.status }}</span>
                                     <span class="font-weight-bold ">{{ summaryLine.number }} ({{
                                             summaryLine.percent
                                         }}%)</span>
+                                    <v-help-text-link class="pl-2 font-lg" :location="'Dashboard - '+summaryLine.status" type="popover"/>
+
                                 </li>
                             </ul>
                         </div>
@@ -268,19 +270,21 @@
                     <div class="row">
                         <div class="col-12 col-md-6">
                             <ul class="list-group list-group-flush">
-                                <li class="list-group-item d-flex font-lg">
+                                <li class="list-group-item d-flex font-lg align-items-center">
                                     <span class="w-50 text-right pr-4">OVERALL SCORE</span>
                                     <span class="font-weight-bold">{{ summary.assessmentScore }}%</span>
+                                    <v-help-text-link class="pl-2 font-lg" location="Dashboard - overall score" type="popover"/>
                                 </li>
                             </ul>
                         </div>
                         <div class="col-12 col-md-6">
                             <ul class="list-group list-group-flush">
-                                <li class="list-group-item d-flex font-lg">
+                                <li class="list-group-item d-flex font-lg align-items-center">
                                     <span class="w-50 text-right pr-4">AE-focused Budget</span>
                                     <span class="font-weight-bold ">{{
                                             formatBudget(summary.aeBudget)
                                         }} {{ organisation.currency }}</span>
+                                    <v-help-text-link class="pl-2 font-lg" location="Dashboard - AE focused budget" type="popover" data-placement="top"/>
                                 </li>
                             </ul>
                         </div>
@@ -293,9 +297,10 @@
                 <div class="card-header d-flex align-items-baseline">
                     <h2 class="mr-4">Summary of Red Flags</h2>
                     <h5>({{ filters.portfolio ? filters.portfolio.name.toUpperCase() : 'ALL PORTFOLIOS' }})</h5>
+                    <v-help-text-link class="pl-2 font-lg" location="Dashboard - Redflags summary"/>
                 </div>
                 <div class="card-body">
-
+                    <v-help-text-entry location="Dashboard - Redflags summary"/>
 
                     <!-- red lines summary -->
                     <table class="table" v-if="summary.redlinesSummary != null">
@@ -342,11 +347,15 @@
         </div>
         <div v-if="tab==='principles'">
             <div class="mx-auto mt-8 w-100" style="max-width: 1500px;" v-if="summary.yoursPrinciplesSummarySorted">
-                <div class="card-header">
+                <div class="card-header d-flex align-items-baseline">
                     <h2 class="mr-4">Summary of Principles</h2>
                     <h5>({{ filters.portfolio ? filters.portfolio.name.toUpperCase() : 'ALL PORTFOLIOS' }})</h5>
+                    <v-help-text-link class="pl-2 font-lg" location="Dashboard - Summary of Principles"/>
+
                 </div>
                 <div class="card-body">
+                    <v-help-text-entry location="Dashboard - Summary of Principles"/>
+
                     <div class="row">
                         <div class="col-12 col-lg-6 d-flex flex-column align-items-center">
                             <h2 class="mb-4">Your Initiatives</h2>
@@ -517,6 +526,7 @@ import {
     LinearScale
 } from 'chart.js'
 import {Bar} from 'vue-chartjs'
+import VHelpTextEntry from "./vHelpTextEntry.vue";
 
 // import ChartDataLabels from 'chartjs-plugin-datalabels';
 

--- a/resources/js/components/MainDashboard.vue
+++ b/resources/js/components/MainDashboard.vue
@@ -2,8 +2,6 @@
 
 
     <div class="container">
-
-
     </div>
     <!-- FILTERS -->
     <div
@@ -226,6 +224,7 @@
     <div class="tab-content">
 
         <div class='tab pane' v-if="tab==='summary'">
+
             <div class="mt-8">
                 <div class="card-header d-flex align-items-baseline">
                     <h2 class="mr-4">Summary of Initiatives</h2>
@@ -235,9 +234,12 @@
                     <div class="row">
                         <div class="col-12 col-lg-6 p-0">
                             <ul class="list-group list-group-flush">
-                                <li class="list-group-item d-flex font-lg">
-                                    <span class="w-50 text-right pr-4"># Initiatives Added</span>
+                                <li class="list-group-item d-flex font-lg align-items-center">
+                                    <span class="w-50 text-right pr-4">
+                                        # Initiatives Added
+                                    </span>
                                     <span class="font-weight-bold ">{{ summary.totalCount }}</span>
+                                    <v-help-text-link class="pl-2 font-lg" location="Dashboard - initiatives added" type="popover"/>
                                 </li>
                                 <li
                                     v-for="summaryLine in summary.statusSummary"
@@ -382,13 +384,14 @@
 import 'vue-select/dist/vue-select.css';
 import vSelect from 'vue-select'
 
+import VHelpTextLink from "./vHelpTextLink.vue";
 import VueDatePicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css'
 
 import {ref, computed, onMounted, watch} from "vue";
 import {isNumber} from "lodash";
 
-const tab = ref('principles')
+const tab = ref('summary')
 
 const props = defineProps({
     user: {
@@ -514,6 +517,7 @@ import {
     LinearScale
 } from 'chart.js'
 import {Bar} from 'vue-chartjs'
+
 // import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)

--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -82,7 +82,7 @@
                         </div>
 
                         <div>
-                            <h6>Presence of Examples // Indicators for {{ principle.name }}</h6>
+                            <h5>Presence of Examples // Indicators <br/>for {{ principle.name }}</h5>
                             <p>Below are some common examples of {{ principle.name }} within a project. Tick the ones that are present within the project. You may also add additional examples below to further support the rating given.</p>
 
                             <div v-for="tag in principle.score_tags" class="checkbox-group mb-2 example-list">

--- a/resources/js/components/vHelpTextEntry.vue
+++ b/resources/js/components/vHelpTextEntry.vue
@@ -1,0 +1,27 @@
+<template>
+    <div class="collapse" :id="sectionId">
+    <div class="bd-callout border-info">
+        {{ helpTextEntry.text }}
+    </div>
+</div>
+</template>
+
+<script setup>
+
+import {onMounted, ref} from "vue";
+
+const props = defineProps({
+    sectionId: String,
+    location: String,
+})
+
+const helpTextEntry = ref({})
+
+onMounted(() => {
+    axios.get('/admin/help-text-entry/find/' + props.location)
+        .then((res) => {
+            helpTextEntry.value = res.data
+        })
+})
+
+</script>

--- a/resources/js/components/vHelpTextEntry.vue
+++ b/resources/js/components/vHelpTextEntry.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="collapse" :id="sectionId">
+    <div class="collapse" :id="targetId">
     <div class="bd-callout border-info">
         {{ helpTextEntry.text }}
     </div>
@@ -7,15 +7,20 @@
 </template>
 
 <script setup>
-
-import {onMounted, ref} from "vue";
+import slugify from 'slugify';
+import {onMounted, ref, computed} from "vue";
 
 const props = defineProps({
-    sectionId: String,
     location: String,
 })
 
+const targetId = computed(() => {
+    return slugify(props.location)
+})
+
 const helpTextEntry = ref({})
+
+
 
 onMounted(() => {
     axios.get('/admin/help-text-entry/find/' + props.location)

--- a/resources/js/components/vHelpTextEntry.vue
+++ b/resources/js/components/vHelpTextEntry.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="collapse" :id="targetId">
-    <div class="bd-callout border-info">
-        {{ helpTextEntry.text }}
+    <div class="bd-callout border-info" v-html="helpTextEntry.text">
     </div>
 </div>
 </template>

--- a/resources/js/components/vHelpTextLink.vue
+++ b/resources/js/components/vHelpTextLink.vue
@@ -10,7 +10,9 @@
         tabindex="0"
         :data-content="helpTextEntry.text"
         role="button"
-        aria-expanded="false">
+        aria-expanded="false"
+        ref="popoverIcon"
+    >
     </i>
 
 </template>
@@ -34,8 +36,11 @@ const targetId = computed(() => {
 
 
 const helpTextEntry = ref({})
+const popoverIcon = ref(null)
 
 onMounted(() => {
+
+    $(popoverIcon.value).popover();
 
     if (props.type === 'popover') {
         axios.get('/admin/help-text-entry/find/' + props.location)

--- a/resources/js/components/vHelpTextLink.vue
+++ b/resources/js/components/vHelpTextLink.vue
@@ -1,18 +1,49 @@
 <template>
+
     <i
         class="ml-2 cursor-help la la-question-circle"
-        data-toggle="collapse"
+        :data-toggle="type"
+        :data-target="type==='collapse' ? '#'+targetId : ''"
+        data-container="body"
+        data-html="true"
+        data-trigger="focus"
+        tabindex="0"
+        :data-content="helpTextEntry.text"
         role="button"
-        aria-expanded="false"
-        :data-target="sectionId">
+        aria-expanded="false">
     </i>
 
 </template>
 
 <script setup>
+import slugify from 'slugify';
+
+import {computed, onMounted, ref} from "vue";
 
 const props = defineProps({
-    sectionId: String,
+    location: String,
+    type: {
+        type: String,
+        default: 'collapse',
+    }
 });
+
+const targetId = computed(() => {
+    return slugify(props.location)
+})
+
+
+const helpTextEntry = ref({})
+
+onMounted(() => {
+
+    if (props.type === 'popover') {
+        axios.get('/admin/help-text-entry/find/' + props.location)
+            .then((res) => {
+                helpTextEntry.value = res.data
+            })
+    }
+})
+
 
 </script>

--- a/resources/js/components/vHelpTextLink.vue
+++ b/resources/js/components/vHelpTextLink.vue
@@ -1,0 +1,18 @@
+<template>
+    <i
+        class="ml-2 cursor-help la la-question-circle"
+        data-toggle="collapse"
+        role="button"
+        aria-expanded="false"
+        :data-target="sectionId">
+    </i>
+
+</template>
+
+<script setup>
+
+const props = defineProps({
+    sectionId: String,
+});
+
+</script>

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -295,3 +295,7 @@ label {
 *[role=button]  {
     cursor: pointer;
 }
+
+.popover {
+    font-size: 1em !important;
+}

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -10,8 +10,6 @@
 @import "~line-awesome/dist/line-awesome/css/line-awesome.min.css";
 @import "~noty/src/noty";
 
-
-
 @import "backpack-form-tweaks";
 @import "redline-radios";
 @import "print-tweaks";
@@ -280,5 +278,20 @@ label {
 }
 
 .btn.active {
+    cursor: pointer;
+}
+
+.bd-callout {
+    padding: 1.25rem;
+    background-color: #fff;
+    border: 1px solid #eee;
+    border-left-width: 0.25rem;
+    border-top-color: #eee !important;
+    border-right-color: #eee !important;
+    border-bottom-color: #eee !important;
+    border-radius: 0.25rem;
+}
+
+*[role=button]  {
     cursor: pointer;
 }

--- a/resources/views/components/help-text-entry.blade.php
+++ b/resources/views/components/help-text-entry.blade.php
@@ -1,4 +1,4 @@
-<div {{ $attributes->class(['collapse']) }} id="{{ $sectionId }}">
+<div {{ $attributes->class(['collapse']) }} id="{{ \Illuminate\Support\Str::slug($location) }}">
     <div class="bd-callout border-info">
         {!! $helpTextEntry->text !!}
     </div>

--- a/resources/views/components/help-text-entry.blade.php
+++ b/resources/views/components/help-text-entry.blade.php
@@ -1,0 +1,5 @@
+<div {{ $attributes->class(['collapse']) }} id="{{ $sectionId }}">
+    <div class="bd-callout border-info">
+        {!! $helpTextEntry->text !!}
+    </div>
+</div>

--- a/resources/views/components/help-text-link.blade.php
+++ b/resources/views/components/help-text-link.blade.php
@@ -3,5 +3,5 @@
    data-toggle="collapse"
     role="button"
     aria-expanded="false"
-    data-target="{{ $sectionId }}">
+    data-target="#{{ $sectionId }}">
 </i>

--- a/resources/views/components/help-text-link.blade.php
+++ b/resources/views/components/help-text-link.blade.php
@@ -3,5 +3,5 @@
    data-toggle="collapse"
     role="button"
     aria-expanded="false"
-    data-target="#{{ $sectionId }}">
+    data-target="#{{ \Illuminate\Support\Str::slug($location)  }}">
 </i>

--- a/resources/views/components/help-text-link.blade.php
+++ b/resources/views/components/help-text-link.blade.php
@@ -1,0 +1,7 @@
+<i
+    {{ $attributes->class(['ml-2 cursor-help la la-question-circle']) }}
+   data-toggle="collapse"
+    role="button"
+    aria-expanded="false"
+    data-target="{{ $sectionId }}">
+</i>

--- a/resources/views/generic-dashboard/dashboard.blade.php
+++ b/resources/views/generic-dashboard/dashboard.blade.php
@@ -5,7 +5,10 @@
     <div class="mt-16 container-fluid" id="dashboard">
 
         <div class="d-flex justify-content-between">
-            <h1 class="font-weight-bold text-deep-green mb-4">{{ $organisation->name }} - Summary</h1>
+            <div class="d-flex align-items-center mb-4">
+            <h1 class="font-weight-bold text-deep-green mb-0">{{ $organisation->name }} - Summary</h1>
+                <x-help-text-link class="font-3xl" location="Dashboard - page title"/>
+            </div>
 
             @if(Auth::user()->can('download project-level data'))
             <div>
@@ -13,6 +16,8 @@
             </div>
             @endif
         </div>
+
+        <x-help-text-entry class="mb-4" location="Dashboard - page title"/>
 
         <v-app>
             <Suspense>
@@ -30,20 +35,5 @@
 @endsection
 
 @section('after_scripts')
-
     @vite('resources/js/dashboard.js')
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.canvaswrapper.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.colorhelpers.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.saturated.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.browser.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.drawSeries.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.uiConstants.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.axislabels.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.legend.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/4.2.3/jquery.flot.stack.js"></script>
-
 @endsection

--- a/resources/views/organisations/members.blade.php
+++ b/resources/views/organisations/members.blade.php
@@ -1,11 +1,11 @@
 <div class="card-header">
     <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Members</h2>
-        <x-help-text-link class="font-2xl" section-id="members-help"/>
+        <x-help-text-link class="font-2xl" location="My Institution - Institution members"/>
     </div>
     <p class="help-block">Review and manage the list of members with access to this institution's information.</p>
 
-    <x-help-text-entry section-id="members-help" location="My Institution - Institution members"/>
+    <x-help-text-entry location="My Institution - Institution members"/>
 
 </div>
 

--- a/resources/views/organisations/members.blade.php
+++ b/resources/views/organisations/members.blade.php
@@ -1,7 +1,14 @@
 <div class="card-header">
-    <h2>Institution Members</h2>
+    <div class="d-flex align-items-center">
+        <h2 class="mb-0">Institution Members</h2>
+        <x-help-text-link class="font-2xl" section-id="#members-help"/>
+    </div>
     <p class="help-block">Review and manage the list of members with access to this institution's information.</p>
+
+    <x-help-text-entry section-id="members-help" location="My Institution - Institution members"/>
+
 </div>
+
 
 <div class="card-body">
 
@@ -17,21 +24,21 @@
         </tr>
         </thead>
         <tbody>
-            @foreach($organisation->users as $user)
-                <tr>
+        @foreach($organisation->users as $user)
+            <tr>
+                <td>
+                    {{ $user->name }}
+                </td>
+                <td>{{ $user->email }}</td>
+                <td>{{ $user->roles->pluck('name')->join(', ') }}</td>
+                @if(Auth::user()->can('maintain institutional members'))
                     <td>
-                        {{ $user->name }}
+                        <a href="{{ route('organisationmembers.edit', [$organisation, $user]) }}" class="btn btn-dark btn-sm" name="edit_member{{ $user->id }}" onclick="">EDIT</a>
+                        <button class="btn btn-dark btn-sm remove-button" data-user="{{ $user->id }}" data-toggle="modal" data-target="#removeUserModal{{ $user->id }}">REMOVE</button>
                     </td>
-                    <td>{{ $user->email }}</td>
-                    <td>{{ $user->roles->pluck('name')->join(', ') }}</td>
-                    @if(Auth::user()->can('maintain institutional members'))
-                        <td>
-                            <a href="{{ route('organisationmembers.edit', [$organisation, $user]) }}" class="btn btn-dark btn-sm" name="edit_member{{ $user->id }}" onclick="">EDIT</a>
-                            <button class="btn btn-dark btn-sm remove-button" data-user="{{ $user->id }}" data-toggle="modal" data-target="#removeUserModal{{ $user->id }}">REMOVE</button>
-                        </td>
-                    @endif
-                </tr>
-            @endforeach
+                @endif
+            </tr>
+        @endforeach
         </tbody>
     </table>
     <hr/>

--- a/resources/views/organisations/members.blade.php
+++ b/resources/views/organisations/members.blade.php
@@ -1,7 +1,7 @@
 <div class="card-header">
     <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Members</h2>
-        <x-help-text-link class="font-2xl" section-id="#members-help"/>
+        <x-help-text-link class="font-2xl" section-id="members-help"/>
     </div>
     <p class="help-block">Review and manage the list of members with access to this institution's information.</p>
 

--- a/resources/views/organisations/portfolios.blade.php
+++ b/resources/views/organisations/portfolios.blade.php
@@ -1,6 +1,14 @@
 <div class="card-header">
-    <h2>Institution Portfolios</h2>
-    <p class="help-block">Review and manage the list of portfolios. All initiatives entered into the platform are part of a portfolio. <br/> <br/> If your institution just has 1 portfolio, please add it here.</p>
+    <div class="d-flex align-items-center">
+        <h2 class="mb-0">Institution Portfolios</h2>
+        <x-help-text-link class="font-2xl" section-id="#portfolios-help"/>
+    </div>
+    <p class="help-block">Review and manage the list of portfolios. All initiatives entered into the platform are part of a portfolio.
+    </p>
+
+    <x-help-text-entry section-id="portfolios-help" location="My Institution - Portfolios"/>
+
+
 </div>
 
 <div class="card-body">

--- a/resources/views/organisations/portfolios.blade.php
+++ b/resources/views/organisations/portfolios.blade.php
@@ -1,7 +1,7 @@
 <div class="card-header">
     <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Portfolios</h2>
-        <x-help-text-link class="font-2xl" section-id="#portfolios-help"/>
+        <x-help-text-link class="font-2xl" section-id="portfolios-help"/>
     </div>
     <p class="help-block">Review and manage the list of portfolios. All initiatives entered into the platform are part of a portfolio.
     </p>

--- a/resources/views/organisations/portfolios.blade.php
+++ b/resources/views/organisations/portfolios.blade.php
@@ -1,12 +1,12 @@
 <div class="card-header">
     <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Portfolios</h2>
-        <x-help-text-link class="font-2xl" section-id="portfolios-help"/>
+        <x-help-text-link class="font-2xl" location="My Institution - Portfolios"/>
     </div>
     <p class="help-block">Review and manage the list of portfolios. All initiatives entered into the platform are part of a portfolio.
     </p>
 
-    <x-help-text-entry section-id="portfolios-help" location="My Institution - Portfolios"/>
+    <x-help-text-entry location="My Institution - Portfolios"/>
 
 
 </div>

--- a/resources/views/organisations/show.blade.php
+++ b/resources/views/organisations/show.blade.php
@@ -4,9 +4,12 @@
 
     <div class="mt-16 container-fluid">
 
-        <div class="w-100 mb-4">
-            <h1 class="text-deep-green"><b>{{$organisation->name}} - Information</b></h1>
+        <div class="w-100 mb-4 d-flex align-items-center">
+            <h1 class="text-deep-green mb-0"><b>{{$organisation->name}} - Information</b></h1>
+            <x-help-text-link class="font-2xl" section-id="#page-info"/>
         </div>
+
+        <x-help-text-entry section-id="page-info" location="My Institution - page title"/>
 
         <ul class="nav nav-tabs mt-4" id="org-tabs" role="tablist">
             <li class="nav-item" role="presentation">

--- a/resources/views/organisations/show.blade.php
+++ b/resources/views/organisations/show.blade.php
@@ -6,7 +6,7 @@
 
         <div class="w-100 mb-4 d-flex align-items-center">
             <h1 class="text-deep-green mb-0"><b>{{$organisation->name}} - Information</b></h1>
-            <x-help-text-link class="font-2xl" section-id="#page-info"/>
+            <x-help-text-link class="font-2xl" section-id="page-info"/>
         </div>
 
         <x-help-text-entry section-id="page-info" location="My Institution - page title"/>

--- a/resources/views/organisations/show.blade.php
+++ b/resources/views/organisations/show.blade.php
@@ -6,10 +6,10 @@
 
         <div class="w-100 mb-4 d-flex align-items-center">
             <h1 class="text-deep-green mb-0"><b>{{$organisation->name}} - Information</b></h1>
-            <x-help-text-link class="font-2xl" section-id="page-info"/>
+            <x-help-text-link class="font-2xl" location="My Institution - page title"/>
         </div>
 
-        <x-help-text-entry section-id="page-info" location="My Institution - page title"/>
+        <x-help-text-entry location="My Institution - page title"/>
 
         <ul class="nav nav-tabs mt-4" id="org-tabs" role="tablist">
             <li class="nav-item" role="presentation">

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -140,3 +140,4 @@ E.g., Centralise instituion selection to a single feature instead of distributin
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('user-feedback') }}"><i class="nav-icon la la-question"></i> User feedback</a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('feedback-type') }}"><i class="nav-icon la la-question"></i> Feedback types</a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('revision') }}"><i class="nav-icon la la-question"></i> Revisions</a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('help-text-item') }}"><i class="nav-icon la la-question"></i> Help text items</a></li>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Admin\AdditionalCriteriaScoreTagCrudController;
 use App\Http\Controllers\Admin\AssessmentCrudController;
 use App\Http\Controllers\Admin\ContinentCrudController;
 use App\Http\Controllers\Admin\CountryCrudController;
+use App\Http\Controllers\Admin\HelpTextEntryCrudController;
 use App\Http\Controllers\Admin\UserFeedbackTypeCrudController;
 use App\Http\Controllers\Admin\InitiativeCategoryCrudController;
 use App\Http\Controllers\Admin\InstitutionTypeCrudController;
@@ -158,7 +159,10 @@ Route::group([
     Route::crud('feedback-type', UserFeedbackTypeCrudController::class);
 
     Route::crud('revision', RevisionCrudController::class);
+    Route::crud('help-text-entry', HelpTextEntryCrudController::class);
+    Route::get('help-text-entry/find/{location}', [HelpTextEntryCrudController::class, 'find']);
 });
+
 Route::get('project/{id}/show-as-pdf', [ProjectCrudController::class, 'show'])
     ->middleware('auth.basic')
     ->name('project.show-as-pdf');


### PR DESCRIPTION
This PR adds the capacity for us to quikly add help text to anywhere within the application. 

Instead of hard-coding the help text into the pages, I wanted to do 2 things:

1. Make it quick for us to add new help text anywhere in the system.
2. Allow Site Managers / Admins to edit the text shown from the admin panel. 

### Developer Tools

The first is achieved through a pair of blade components and vue components - I made both so we can use them on blade/php rendered pages and within Vue component pages. 

- the `x-help-text-link` and `v-help-text-link` components display a `?` symbol, and when clicked on *either* show the corresponding `x-help-text-entry` / `v-help-text-entry` collapsible component, *or* show a popover. The collapse is the default, and you can make it a popover by adding the attribute `type="popover"`. 
- Each component needs a `location` attribute. This matches to a HelpTextEntry database entry, and will display the `text` property from that location. 

This means we can quickly add some help text to anywhere in the sytem by adding a database entry and the appropriate component in the right place/places. 

### Site Manager Tools

The HelpTextEntryCrudController shoiuld allow site managers to review and edit the HelpTextEntry items in the database. 
 - They cannot add new entries. Adding new entries requires a change to the code in order to render that help text somewhere on the front-end. 
 - They cannot delete entries, for obvious reasons.
 - They can edit the text.

This crud panel should be added to the back-end when we merge this in with #201. 