### PR TITLE
Get One Day Exchange Rates Data

### DIFF
--- a/app/Console/Commands/GetExchangeRatesForOneDay.php
+++ b/app/Console/Commands/GetExchangeRatesForOneDay.php
@@ -30,10 +30,8 @@ class GetExchangeRatesForOneDay extends Command
      */
     public function handle()
     {
-        // get the date before yesterday
-        // Freecurrency API provides exchange rate data up to yesterday, consider time difference and time zones,
-        // reserve more buffer to get data of the date before yesterday instead of yesterday
-        $date = Carbon::now()->subDays(2)->toDateString();
+        // get yesterday date
+        $date = Carbon::now()->subDays(1)->toDateString();
 
         // remove existing exchange_rates records for the date, if any
         DB::table('exchange_rates')->where('date', $date)->delete();

--- a/app/Console/Commands/GetExchangeRatesForOneDay.php
+++ b/app/Console/Commands/GetExchangeRatesForOneDay.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use App\Models\Currency;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use App\Jobs\GetOneDayExchangeRates;
+use Illuminate\Support\Facades\Http;
+
+class GetExchangeRatesForOneDay extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:get-one-day-exchange-rates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add jobs to the queue to get historical exchange rates for one day only.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // get the date before yesterday
+        // Freecurrency API provides exchange rate data up to yesterday, consider time difference and time zones,
+        // reserve more buffer to get data of the date before yesterday instead of yesterday
+        $date = Carbon::now()->subDays(2)->toDateString();
+
+        // remove existing exchange_rates records for the date, if any
+        DB::table('exchange_rates')->where('date', $date)->delete();
+
+        $currencies = Currency::all();
+
+        foreach ($currencies as $currency) {
+            GetOneDayExchangeRates::dispatch($currency, $date);
+            $this->comment('dispatched job for ' . $currency . ' and the date ' . $date);
+        }
+
+        $this->info('done!');
+
+    }
+
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,7 +29,7 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('senddataremovalreminderemail')->dailyAt('00:11');
 
-        $schedule->command('app:get-one-day-exchange-rates')->dailyAt('00:21');
+        $schedule->command('app:get-one-day-exchange-rates')->dailyAt('06:00');
 
         $schedule->command('app:remove-old-pdf-prints')->weeklyOn('sunday', '01:00');
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,6 +29,8 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('senddataremovalreminderemail')->dailyAt('00:11');
 
+        $schedule->command('app:get-one-day-exchange-rates')->dailyAt('00:21');
+
         $schedule->command('app:remove-old-pdf-prints')->weeklyOn('sunday', '01:00');
 
         $schedule->command('media-library:delete-old-temporary-uploads')->daily();

--- a/app/Http/Controllers/ExchangeRateController.php
+++ b/app/Http/Controllers/ExchangeRateController.php
@@ -21,13 +21,24 @@ class ExchangeRateController
 
 
 
-        return ExchangeRate::where('date', $validated['date'])
-            ->where('base_currency_id', $validated['base_currency_id'])
-            ->where('target_currency_id', $validated['target_currency_id'])
+        $rate = $this->getExchangeRate($validated);
+
+        // if no exchange rate exists for the given date + currency combo, try the day before.
+        if(!$rate) {
+            $validated['date'] = (new Carbon($validated['date']))->subDay();
+            $rate = $this->getExchangeRate($validated);
+        }
+
+        return $rate;
+
+    }
+
+    public function getExchangeRate(array $data): ?ExchangeRate
+    {
+        return ExchangeRate::where('date', $data['date'])
+            ->where('base_currency_id', $data['base_currency_id'])
+            ->where('target_currency_id', $data['target_currency_id'])
             ->first();
-
-
-
     }
 
 }

--- a/app/Jobs/GetOneDayExchangeRates.php
+++ b/app/Jobs/GetOneDayExchangeRates.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\RateLimited;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
@@ -38,6 +39,11 @@ class GetOneDayExchangeRates implements ShouldQueue
         ];
     }
 
+    public function retryUntil(): \DateTime
+    {
+        return now()->addMinutes(10);
+    }
+
     /**
      * Execute the job.
      * @throws RequestException
@@ -56,7 +62,9 @@ class GetOneDayExchangeRates implements ShouldQueue
                 'date_from' => $startDate,
                 'date_to' => $endDate,
             ])
-            ->throw()
+            ->throw(function (Response $response, RequestException $exception) {
+                Log::error($exception->getMessage());
+            })
             ->json();
 
 

--- a/app/Jobs/GetOneDayExchangeRates.php
+++ b/app/Jobs/GetOneDayExchangeRates.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Currency;
+use App\Models\ExchangeRate;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Queue\Middleware\ThrottlesExceptions;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class GetOneDayExchangeRates implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public Currency $currency, public string $date)
+    {
+        //
+    }
+
+    // what middleware should the job pass through?
+    public function middleware(): array
+    {
+        return [
+            new RateLimited('exchange_rates'),
+            //new ThrottlesExceptions(1, 1),
+        ];
+    }
+
+    /**
+     * Execute the job.
+     * @throws RequestException
+     */
+    public function handle(): void
+    {
+        $startDate = $this->date;
+        $endDate = $this->date;
+
+        // api call
+        $response = Http::withHeaders([
+            'apiKey' => config('services.currency.api-key')
+        ])
+            ->get('https://api.freecurrencyapi.com/v1/historical', [
+                'base_currency' => $this->currency->id,
+                'date_from' => $startDate,
+                'date_to' => $endDate,
+            ])
+            ->throw()
+            ->json();
+
+
+        $rates = [];
+
+        foreach ($response['data'] as $date => $values) {
+
+            foreach ($values as $key => $value) {
+
+                $rates[] = [
+                    'base_currency_id' => $this->currency->id,
+                    'target_currency_id' => $key,
+                    'date' => $date,
+                    'rate' => $value,
+                ];
+
+            }
+        }
+
+        $this->currency->exchangeRates()->createMany($rates);
+
+    }
+
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,8 +39,8 @@ class AppServiceProvider extends ServiceProvider
 
 
         // add rate limiter for Currency Exchange API jobs
-        RateLimiter::for('exchange_rates', function () {
-            return Limit::perMinute(5);
+        RateLimiter::for('exchange_rates', function (object $job) {
+            return Limit::perMinute(5)->by($job->date);
         });
 
     }


### PR DESCRIPTION
This PR is submitted to fix #124.

Freecurrency API provides exchange rate data up to yesterday, consider time difference and time zones, reserve more buffer to get data of the date before yesterday instead of yesterday.

Command:
php artisan app:get-daily-exchange-rates

The schedule job will be executed at 00:21 AM everyday.

---

I intended to modify GetHistoricExchangeRates.php to support this feature. But I realised that this class cannot have another constructor method with different parameters. Finally I copy it as GetOneDayExchangeRates.php.
