### PR TITLE
Review init review

### DIFF
--- a/app/View/Components/HelpTextLink.php
+++ b/app/View/Components/HelpTextLink.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class HelpTextLink extends Component
+{
+
+    public \App\Models\HelpTextEntry $helpTextEntry;
+
+    public function __construct(
+        public string $location,
+        public string $type = 'collapse'
+    )
+    {
+        $this->helpTextEntry = \App\Models\HelpTextEntry::firstWhere('location', $location);
+
+    }
+
+    public function render(): View
+    {
+
+        return view('components.help-text-link');
+    }
+}

--- a/database/migrations/2023_08_08_101457_set_rating_to_1dp_in_principle_assessment_table.php
+++ b/database/migrations/2023_08_08_101457_set_rating_to_1dp_in_principle_assessment_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('principle_assessment', function (Blueprint $table) {
+            $table->decimal('rating', 8, 1)->nullable()->change();
+        });
+
+        Schema::table('additional_criteria_assessment', function (Blueprint $table) {
+            $table->decimal('rating', 8, 1)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('1dp_in_principle_assessment', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/sass/_print-tweaks.scss
+++ b/resources/sass/_print-tweaks.scss
@@ -12,14 +12,25 @@
         max-width: 33.3333333333333%;
     }
 
-        .print-6 {
+    .print-6 {
         flex: 0 0 50%;
         max-width: 50%;
     }
 
-        .print-8 {
+    .print-8 {
         flex: 0 0 66.6666666666667%;
         max-width: 66.6666666666667%;
     }
 
+    .print-page-break {
+        page-break-before: always;
+    }
+
+
+}
+
+@media not print {
+    .only-print {
+        display: none !important;
+    }
 }

--- a/resources/views/components/help-text-link.blade.php
+++ b/resources/views/components/help-text-link.blade.php
@@ -1,7 +1,14 @@
 <i
     {{ $attributes->class(['ml-2 cursor-help la la-question-circle']) }}
-   data-toggle="collapse"
+    data-toggle="{{ $type }}"
+    data-container="body"
+    data-html="true"
+    data-trigger="focus"
+    tabindex="0"
     role="button"
     aria-expanded="false"
-    data-target="#{{ \Illuminate\Support\Str::slug($location)  }}">
+    data-target="#{{ \Illuminate\Support\Str::slug($location)  }}"
+    data-content="{{ $helpTextEntry->text }}"
+
+>
 </i>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -68,31 +68,7 @@
                             <td>{{ $entry->sub_regions }}</td>
                         </tr>
                     @endif
-                    <tr>
-                        <td class="text-right pr-4 mr-2">Status:</td>
-                        <td>{{ $entry->latest_assessment_status }}</td>
-                    </tr>
 
-                    <tr>
-                        <td class="text-right pr-4 mr-2">Ratings Total:</td>
-                        @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value)
-                            <td>{{ $entry->latest_assessment->total }} / {{ $entry->latest_assessment->total_possible }}</td>
-                        @else
-                            <td class="text-secondary">~~ Assessment not yet completed ~~</td>
-                        @endif
-                    </tr>
-                    <tr>
-                        <td class="text-right pr-4 mr-2">Overall Score:</td>
-                        @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value)
-                            <td>
-                                <span class="font-weight-bold">{{ $entry->latest_assessment->overall_score }} % </span>
-                                <br/>
-                                <span class="text-sm text-secondary">Calculated based on {{ $entry->latest_assessment->principleAssessments()->where('is_na', 0)->count() }} / 13 relevant principles.</span>
-                            </td>
-                        @else
-                            <td class="text-secondary">~~ Assessment not yet completed ~~</td>
-                        @endif
-                    </tr>
                 </table>
             </div>
 
@@ -121,6 +97,21 @@
 
             </div>
         </div>
+
+        @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value || $entry->latest_assessment->redline_status === \App\Enums\AssessmentStatus::Failed->value)
+            <hr/>
+            <div class="row mt-4">
+                <div class="col-12 d-flex justify-content-center align-items-center">
+                    <span class="mr-4 font-lg">Overall Score for this initiative: </span>
+                    <span class="font-weight-bold font-xl">{{ $entry->latest_assessment->overall_score }} % </span>
+                    <x-help-text-link class="no-print" location="Initiatives - score" type="popover"></x-help-text-link>
+                </div>
+                <div class="col-12 mt-4 d-flex align-items-center justify-content-center flex-column">
+                    <span class="text-secondary">Calculated based on the total score, divided by the total possible score for all applicable principles.</span>
+                    <span class="font-weight-bold">( {{ $entry->latest_assessment->total }} / {{ $entry->latest_assessment->total_possible }} ) * 100</span>
+                </div>
+            </div>
+        @endif
 
         <div class="print-page-break">
             <h1 class="only-print mt-16">{{ $entry->organisation->name }} - {{ \Illuminate\Support\Str::title($entry->name) }}</h1>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -6,8 +6,8 @@
 
     <div class="container mt-4">
 
-        <h1>Initiative Review Page</h1>
-        <h2>{{ $entry->organisation->name }} - {{ $entry->name }}</h2>
+        <h1>{{ $entry->organisation->name }} - {{ \Illuminate\Support\Str::title($entry->name) }}</h1>
+        <h4 class="text-uppercase">Initiative Summary</h4>
 
         <form method="POST" action="{{ backpack_url("project/$entry->id/generate-pdf") }}">
             @csrf
@@ -108,17 +108,26 @@
                                     <li>{{ $principleAssessment->principle->name }}</li>
                                 @endforeach
                             </ul>
+                        </div>
                     @endif
 
                 @elseif($entry->latest_assessment->redline_status === \App\Enums\AssessmentStatus::Failed->value)
-                    <p class="text-center text-secondary">~~ Red flag assessment failed ~~<br/>~~ no principle assessment results available ~~</p>
+                    <p class="text-center text-secondary">~~ Red flag assessment failed ~~<br/>~~ no principle assessment results available ~~
+                    </p>
                 @else
-                    <p class="text-center text-secondary">~~ Principle assessment not completed ~~<br/>~~ no results available ~~</p>
+                    <p class="text-center text-secondary">~~ Principle assessment not completed ~~<br/>~~ no results available ~~
+                    </p>
                 @endif
 
             </div>
         </div>
-        <div class="row">
+
+        <div class="print-page-break">
+            <h1 class="only-print mt-16">{{ $entry->organisation->name }} - {{ \Illuminate\Support\Str::title($entry->name) }}</h1>
+            <h4 class="only-print text-uppercase">Principle Assessment Summary</h4>
+        </div>
+
+        <div class="row mt-4 pt-4">
             <div class="col-12">
                 <table class="table table-borderless table-responsive">
                     <tr>


### PR DESCRIPTION
PR to fix #197:

- removed duplicate budget entry when the initiative's budget is the same as the organisation's.
- changed the layout to highlight the overall score more prominently, and add explanation of the score with help text.
- modified the print layout so that the principle summary appears on a new page with a title. 
- hidden the principle summary table if the main principle assessment is not complete (e.g. if the red flags were failed).

Also added a minor fix so that the blade help-text-link can now also act as a popover.