### PR TITLE
Review initiative sorting

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -71,8 +71,8 @@ class ProjectController extends Controller
         }
 
         // get settings from session
-        $sortBy = Session::get('sortBy') ?? '';
-        $sortDir = Session::get('sortDir') ?? '';
+        $sortBy = Session::get('sortBy') ?? 'name';
+        $sortDir = Session::get('sortDir') ?? 1;
         $redlineStatusFilterValue = Session::get('redlineStatusFilterValue') ?? '';
         $principleStatusFilterValue = Session::get('principleStatusFilterValue') ?? '';
         $portfolioFilter = Session::get('portfolioFilter') ?? '';

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -31,7 +31,7 @@ class ProjectFactory extends Factory
             'initiative_category_id' => $initiativeCategory,
             'initiative_category_other' => $initiativeCategoryOther,
             'budget' => $this->faker->randomNumber(),
-            'created_at' => Carbon::now(),
+            'created_at' => $this->faker->dateTimeBetween('- 2 years', 'now'),
             'updated_at' => Carbon::now(),
             'currency' => $this->faker->currencyCode(),
             'exchange_rate' => $this->faker->numberBetween(1, 20) / 10,

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -26,5 +26,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ProjectSeeder::class);
         $this->call(ScoreTagsTableSeeder::class);
         $this->call(ExchangeRatesTableSeeder::class);
+        $this->call(HelpTextEntrySeeder::class);
     }
 }


### PR DESCRIPTION
Fixes #190.

Minor PR to set the correct default initiative sort settings when there is nothing in the Session storage. Previously the sorting and sort direction were set to 0, which meant there was no selected sort-by and the sort direction didn't work until you hit reset.

Also updated the project factory so the created_at for generated projects is randomised. I used this to check the created_at sort, which works correctly 👍.  