### PR TITLE
Fix Members permissions

### DIFF
--- a/app/Http/Controllers/Admin/AdditionalCriteriaCrudController.php
+++ b/app/Http/Controllers/Admin/AdditionalCriteriaCrudController.php
@@ -19,6 +19,7 @@ use Backpack\Pro\Http\Controllers\Operations\FetchOperation;
 use Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Prologue\Alerts\Facades\Alert;
 
@@ -40,6 +41,10 @@ class AdditionalCriteriaCrudController extends CrudController
         CRUD::setModel(\App\Models\AdditionalCriteria::class);
         CRUD::setRoute(config('backpack.base.route_prefix') . '/additional-criteria');
         CRUD::setEntityNameStrings('additional criteria', 'additional criteria');
+
+        if(Auth::user()->cannot('maintain custom principles')) {
+            CRUD::denyAccess(['update', 'create', 'delete']);
+        }
     }
 
     protected function setupListOperation()

--- a/app/View/Components/HelpTextLink.php
+++ b/app/View/Components/HelpTextLink.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class HelpTextLink extends Component
+{
+
+    public \App\Models\HelpTextEntry $helpTextEntry;
+
+    public function __construct(
+        public string $location,
+        public string $type = 'collapse'
+    )
+    {
+        $this->helpTextEntry = \App\Models\HelpTextEntry::firstWhere('location', $location);
+
+    }
+
+    public function render(): View
+    {
+
+        return view('components.help-text-link');
+    }
+}

--- a/database/migrations/2023_08_08_101457_set_rating_to_1dp_in_principle_assessment_table.php
+++ b/database/migrations/2023_08_08_101457_set_rating_to_1dp_in_principle_assessment_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('principle_assessment', function (Blueprint $table) {
+            $table->decimal('rating', 8, 1)->nullable()->change();
+        });
+
+        Schema::table('additional_criteria_assessment', function (Blueprint $table) {
+            $table->decimal('rating', 8, 1)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('1dp_in_principle_assessment', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -202,7 +202,7 @@ class RoleSeeder extends Seeder
         $insMember->givePermissionTo('request to leave an institution');
         $insMember->givePermissionTo('auto set default institution');
         $insMember->givePermissionTo('view custom principles');
-        $insMember->givePermissionTo('maintain custom principles');
+        $insMember->givePermissionTo('view portfolios');
 
     }
 }

--- a/resources/sass/_print-tweaks.scss
+++ b/resources/sass/_print-tweaks.scss
@@ -12,14 +12,25 @@
         max-width: 33.3333333333333%;
     }
 
-        .print-6 {
+    .print-6 {
         flex: 0 0 50%;
         max-width: 50%;
     }
 
-        .print-8 {
+    .print-8 {
         flex: 0 0 66.6666666666667%;
         max-width: 66.6666666666667%;
     }
 
+    .print-page-break {
+        page-break-before: always;
+    }
+
+
+}
+
+@media not print {
+    .only-print {
+        display: none !important;
+    }
 }

--- a/resources/views/components/help-text-link.blade.php
+++ b/resources/views/components/help-text-link.blade.php
@@ -1,7 +1,14 @@
 <i
     {{ $attributes->class(['ml-2 cursor-help la la-question-circle']) }}
-   data-toggle="collapse"
+    data-toggle="{{ $type }}"
+    data-container="body"
+    data-html="true"
+    data-trigger="focus"
+    tabindex="0"
     role="button"
     aria-expanded="false"
-    data-target="#{{ \Illuminate\Support\Str::slug($location)  }}">
+    data-target="#{{ \Illuminate\Support\Str::slug($location)  }}"
+    data-content="{{ $helpTextEntry->text }}"
+
+>
 </i>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -6,8 +6,8 @@
 
     <div class="container mt-4">
 
-        <h1>Initiative Review Page</h1>
-        <h2>{{ $entry->organisation->name }} - {{ $entry->name }}</h2>
+        <h1>{{ $entry->organisation->name }} - {{ \Illuminate\Support\Str::title($entry->name) }}</h1>
+        <h4 class="text-uppercase">Initiative Summary</h4>
 
         <form method="POST" action="{{ backpack_url("project/$entry->id/generate-pdf") }}">
             @csrf
@@ -26,10 +26,12 @@
                         <td class="text-right pr-4 mr-2">Budget:</td>
                         <td>{{ $entry->currency }} {{ $entry->budget }}</td>
                     </tr>
-                    <tr>
-                        <td class="text-right pr-4 mr-2">Budget (in {{ $entry->organisation->currency }}):</td>
-                        <td>{{ $entry->organisation->currency }} {{ $entry->budget_org }}</td>
-                    </tr>
+                    @if($entry->currency !== $entry->organisation->currency)
+                        <tr>
+                            <td class="text-right pr-4 mr-2">Budget (in {{ $entry->organisation->currency }}):</td>
+                            <td>{{ $entry->organisation->currency }} {{ $entry->budget_org }}</td>
+                        </tr>
+                    @endif
                     <tr>
                         <td class="text-right pr-4 mr-2">Start Date:</td>
                         <td>{{ $entry->start_date->toDateString() }}</td>
@@ -68,31 +70,7 @@
                             <td>{{ $entry->sub_regions }}</td>
                         </tr>
                     @endif
-                    <tr>
-                        <td class="text-right pr-4 mr-2">Status:</td>
-                        <td>{{ $entry->latest_assessment_status }}</td>
-                    </tr>
 
-                    <tr>
-                        <td class="text-right pr-4 mr-2">Ratings Total:</td>
-                        @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value)
-                            <td>{{ $entry->latest_assessment->total }} / {{ $entry->latest_assessment->total_possible }}</td>
-                        @else
-                            <td class="text-secondary">~~ Assessment not yet completed ~~</td>
-                        @endif
-                    </tr>
-                    <tr>
-                        <td class="text-right pr-4 mr-2">Overall Score:</td>
-                        @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value)
-                            <td>
-                                <span class="font-weight-bold">{{ $entry->latest_assessment->overall_score }} % </span>
-                                <br/>
-                                <span class="text-sm text-secondary">Calculated based on {{ $entry->latest_assessment->principleAssessments()->where('is_na', 0)->count() }} / 13 relevant principles.</span>
-                            </td>
-                        @else
-                            <td class="text-secondary">~~ Assessment not yet completed ~~</td>
-                        @endif
-                    </tr>
                 </table>
             </div>
 
@@ -108,66 +86,95 @@
                                     <li>{{ $principleAssessment->principle->name }}</li>
                                 @endforeach
                             </ul>
+                        </div>
                     @endif
 
                 @elseif($entry->latest_assessment->redline_status === \App\Enums\AssessmentStatus::Failed->value)
-                    <p class="text-center text-secondary">~~ Red flag assessment failed ~~<br/>~~ no principle assessment results available ~~</p>
+                    <p class="text-center text-secondary">~~ Red flag assessment failed ~~<br/>~~ no principle assessment results available ~~
+                    </p>
                 @else
-                    <p class="text-center text-secondary">~~ Principle assessment not completed ~~<br/>~~ no results available ~~</p>
+                    <p class="text-center text-secondary">~~ Principle assessment not completed ~~<br/>~~ no results available ~~
+                    </p>
                 @endif
 
             </div>
         </div>
-        <div class="row">
-            <div class="col-12">
-                <table class="table table-borderless table-responsive">
-                    <tr>
-                        <th>Principle</th>
-                        <th>Score</th>
-                        <th>Comments</th>
-                        <th>Shared Examples/Indicators</th>
-                        <th>Custom Examples/Indicators</th>
-                    </tr>
 
-                    @php
-                        $principleAssessments = $entry->latest_assessment->principleAssessments;
-                    @endphp
+        @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value || $entry->latest_assessment->redline_status === \App\Enums\AssessmentStatus::Failed->value)
+            <hr/>
+            <div class="row mt-4">
+                <div class="col-12 d-flex justify-content-center align-items-center">
+                    <span class="mr-4 font-lg">Overall Score for this initiative: </span>
+                    <span class="font-weight-bold font-xl">{{ $entry->latest_assessment->overall_score }} % </span>
+                    <x-help-text-link class="no-print" location="Initiatives - score" type="popover"></x-help-text-link>
+                </div>
+                <div class="col-12 mt-4 d-flex align-items-center justify-content-center flex-column">
+                    @if($entry->latest_assessment->redline_status ===  \App\Enums\AssessmentStatus::Failed->value)
+                        <span class="text-secondary">Initiatives that fail the red flag assessment automatically receive a score of 0%.</span>
+                    @else
+                        <span class="text-secondary">Calculated based on the total score, divided by the total possible score for all applicable principles.</span>
+                        <span class="font-weight-bold">( {{ $entry->latest_assessment->total }} / {{ $entry->latest_assessment->total_possible }} ) * 100</span>
+                    @endif
+                </div>
+            </div>
+        @endif
 
-                    @foreach(\App\Models\Principle::all() as $principle)
+        @if($entry->latest_assessment->principle_status === \App\Enums\AssessmentStatus::Complete->value)
+            <div class="print-page-break">
+                <h1 class="only-print mt-16">{{ $entry->organisation->name }} - {{ \Illuminate\Support\Str::title($entry->name) }}</h1>
+                <h4 class="only-print text-uppercase">Principle Assessment Summary</h4>
+            </div>
+
+            <div class="row mt-4 pt-4">
+                <div class="col-12">
+                    <table class="table table-borderless table-responsive">
+                        <tr>
+                            <th>Principle</th>
+                            <th>Score</th>
+                            <th>Comments</th>
+                            <th>Shared Examples/Indicators</th>
+                            <th>Custom Examples/Indicators</th>
+                        </tr>
 
                         @php
-                            $principleAssessment = $principleAssessments->where('principle_id', $principle->id)->first();
+                            $principleAssessments = $entry->latest_assessment->principleAssessments;
                         @endphp
-                        <tr>
-                            <td>{{ $principle->name }}</td>
-                            <td> {{ $principleAssessment->is_na ? "NA" : $principleAssessment->rating }}</td>
-                            <td> {{ $principleAssessment->is_na ? "-" : $principleAssessment->rating_comment }}</td>
-                            <td>
-                                @if($principleAssessment->scoreTags()->count() > 0)
-                                    <button class="btn btn-link" type="button" data-toggle="modal"
-                                            data-target="#modal-shared-{{$principle->id}}">
-                                        {{ $principleAssessment->scoreTags()->count() }} selected
-                                    </button>
-                                @else
-                                    <span class="btn">0 selected</span>
-                                @endif
-                            </td>
-                            <td>
-                                @if($principleAssessment->customScoreTags()->count() > 0)
-                                    <button class="btn btn-link" type="button" data-toggle="modal"
-                                            data-target="#modal-custom-shared-{{$principle->id}}">
-                                        {{ $principleAssessment->customScoreTags()->count() }} added
-                                    </button>
-                                @else
-                                    <span class="btn">0 added</span>
-                                @endif
-                            </td>
-                        </tr>
-                    @endforeach
 
-                </table>
+                        @foreach(\App\Models\Principle::all() as $principle)
+
+                            @php
+                                $principleAssessment = $principleAssessments->where('principle_id', $principle->id)->first();
+                            @endphp
+                            <tr>
+                                <td>{{ $principle->name }}</td>
+                                <td> {{ $principleAssessment->is_na ? "NA" : $principleAssessment->rating }}</td>
+                                <td> {{ $principleAssessment->is_na ? "-" : $principleAssessment->rating_comment }}</td>
+                                <td>
+                                    @if($principleAssessment->scoreTags()->count() > 0)
+                                        <button class="btn btn-link" type="button" data-toggle="modal"
+                                                data-target="#modal-shared-{{$principle->id}}">
+                                            {{ $principleAssessment->scoreTags()->count() }} selected
+                                        </button>
+                                    @else
+                                        <span class="btn">0 selected</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    @if($principleAssessment->customScoreTags()->count() > 0)
+                                        <button class="btn btn-link" type="button" data-toggle="modal"
+                                                data-target="#modal-custom-shared-{{$principle->id}}">
+                                            {{ $principleAssessment->customScoreTags()->count() }} added
+                                        </button>
+                                    @else
+                                        <span class="btn">0 added</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+
+                    </table>
+                </div>
             </div>
-        </div>
     </div>
 
     @foreach(\App\Models\Principle::all() as $principle)
@@ -248,6 +255,7 @@
         </div>
     @endforeach
 
+    @endif
 @endsection
 
 @section('after_scripts')


### PR DESCRIPTION
This PR fixes #203:

- updated RoleSeeder to add the `view portfolios` to institutional members, and remove the `maintain custom principles`.
- Updated the AdditionalCriteriaCrudController to deny access to create/update/delete operations unless you have the `maintain custom principles` permission. 
  - even though we were hiding the buttons on the main My Institution page, you could still click through to "View", then the edit + delete options were shown on that page. With this update, those buttons no longer show. 

NOTE: This PR includes PR #210, because my local version started expecting the View Component class for x-help-text-link added in that PR. I recommend not reviewing this one until 210 is merged in, so then the changes made here will be much more clear. 

ALSO NOTE: Institutional members can still 'delete' institutions in this version. That issue is fixed in #208. 