### PR TITLE
FIX: Get help text only once for initiative cards

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\HelpTextEntry;
 use App\Models\Project;
 use App\Models\Portfolio;
 use Illuminate\Support\Str;
@@ -96,6 +97,10 @@ class ProjectController extends Controller
             'searchString' => $searchString,
         ];
 
+        // get help text for cards. We do this manually here so that we don't need to send ajax requests from every card individually.
+        $statusHelpText = HelpTextEntry::firstWhere('location', 'Initiatives - statuses');
+        $scoreHelpText = HelpTextEntry::firstWhere('location', 'Initiatives - score');
+
         return view('projects.index', [
             'organisation' => $org,
             'projects' => $projects,
@@ -108,6 +113,8 @@ class ProjectController extends Controller
             'enable_assess_button' => $enableAssessButton,
             'enable_delete_button' => $enableDeleteButton,
             'settings' => $settings,
+            'statusHelpText' => $statusHelpText,
+            'scoreHelpText' => $scoreHelpText,
         ]);
     }
 

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -12,13 +12,13 @@
                     <div class="d-flex justify-content-between">
                         <div class="w-50">
                             <span class="font-weight-bold text-grey">STATUS</span>
-                            <v-help-text-link location="Initiatives - statuses" type="popover"/>
+                            <v-help-text-link location="Initiatives - statuses" type="popover" :help-text-entry-init="statusHelpText"/>
                             <br/>
                             <span class="font-weight-bold">{{ initiative.latest_assessment.assessment_status }}</span>
                         </div>
                         <div class="w-50">
                             <span class="font-weight-bold text-grey">SCORE</span>
-                            <v-help-text-link location="Initiatives - score" type="popover"/>
+                            <v-help-text-link location="Initiatives - score" type="popover" :help-text-entry-init="scoreHelpText"/>
                             <br/>
                             <span class="font-xl text-bright-green font-weight-bold"
                                   v-if="initiative.latest_assessment.overall_score !== null">{{
@@ -151,6 +151,8 @@ const props = defineProps({
     enableShowButton: Boolean,
     enableAssessButton: Boolean,
     enableDeleteButton: Boolean,
+    statusHelpText: Object,
+    scoreHelpText: Object,
 })
 
 const expanded = ref(false)

--- a/resources/js/components/InitiativesList.vue
+++ b/resources/js/components/InitiativesList.vue
@@ -93,6 +93,8 @@
         :enable-edit-button="enableEditButton"
         :enable-show-button="enableShowButton"
         :enable-assess-button="enableAssessButton"
+        :status-help-text="statusHelpText"
+        :score-help-text="scoreHelpText"
     />
 
 </template>
@@ -109,6 +111,8 @@ import VHelpTextEntry from "./vHelpTextEntry.vue";
 
 
 const props = defineProps({
+    statusHelpText: Object,
+    scoreHelpText: Object,
     organisation: Object,
     initialInitiatives: Object,
     hasAdditionalAssessment: Boolean,

--- a/resources/js/components/vHelpTextLink.vue
+++ b/resources/js/components/vHelpTextLink.vue
@@ -27,6 +27,10 @@ const props = defineProps({
     type: {
         type: String,
         default: 'collapse',
+    },
+    helpTextEntryInit: {
+        type: Object,
+        default: null,
     }
 });
 
@@ -42,11 +46,14 @@ onMounted(() => {
 
     $(popoverIcon.value).popover();
 
-    if (props.type === 'popover') {
-        axios.get('/admin/help-text-entry/find/' + props.location)
-            .then((res) => {
-                helpTextEntry.value = res.data
-            })
+    if (props.type === 'popover')
+        if(props.helpTextEntryInit === null) {
+            axios.get('/admin/help-text-entry/find/' + props.location)
+                .then((res) => {
+                    helpTextEntry.value = res.data
+                })
+        } else {
+            helpTextEntry.value = props.helpTextEntryInit;
     }
 })
 

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -25,6 +25,8 @@
             :enable-delete-button="{{ $enable_delete_button ? 'true' : 'false'}}"
             :enable-assess-button="{{ $enable_assess_button ? 'true' : 'false' }}"
             :settings="{{ json_encode($settings) }}"
+            :status-help-text="{{ $statusHelpText }}"
+            :score-help-text="{{ $scoreHelpText }}"
         />
     </div>
 


### PR DESCRIPTION
The issue: On the initiative list page, the new help-text items were sending ajax requests to retrieve the correct text from the database. But it was causing 2 ajax requests per initiative card, all retrieving the same data. 

This PR is a quick hack to manually retrieve those HelpTextEntry items as part of the initial page load, and pass them down into the Vue components, thus avoiding the un-needed ajax requests. 

