### PR TITLE
re-add removeInitiative event handler

### DIFF
--- a/resources/js/components/InitiativesList.vue
+++ b/resources/js/components/InitiativesList.vue
@@ -88,6 +88,7 @@
     <InitiativeListCard
         v-for="initiative in filteredInitiatives"
         :key="initiative.id"
+        @remove_initiative="removeInitiative"
         @refresh_initiative="refreshInitiative"
         :initiative="initiative"
         :has-additional-assessment="hasAdditionalAssessment"


### PR DESCRIPTION
FIxes delete initiative option that was broken in merging a while back. 