### PR TITLE
Fix Principle Rating Issue in Dashboard

### DIFF
--- a/database/seeders/DashboardRatingSeeder.php
+++ b/database/seeders/DashboardRatingSeeder.php
@@ -15,8 +15,22 @@ class DashboardRatingSeeder extends Seeder
      */
     public function run()
     {
-        DB::insert('INSERT INTO dashboard_rating (id, category, min_rating, max_rating) VALUES (?, ?, ?, ?)', [1, 'GREEN', 1.5, 2.0]);
+        // mix_rating and max_rating will be used for principle rating in dashbaord
+        // the condition in SQL is something like:
+        //      WHERE ta.rating >= tb.min_rating
+        //      AND ta.rating < tb.max_rating
+        // 
+        // The actual range for different rating are:
+        // RED:    0.00 - 0.49
+        // YELLOW: 0.50 - 1.49
+        // GREEN:  1.50 - 2.00
+
+        // due to the WHERE clause in above SQL, max_rating for GREEN needs to be 2.01 instead of 2.00
+        // P.S. If max_rating is 2.00, those principle with score 2.00 will be excluded
+        DB::insert('INSERT INTO dashboard_rating (id, category, min_rating, max_rating) VALUES (?, ?, ?, ?)', [1, 'GREEN', 1.5, 2.01]);
+
         DB::insert('INSERT INTO dashboard_rating (id, category, min_rating, max_rating) VALUES (?, ?, ?, ?)', [2, 'YELLOW', 0.5, 1.5]);
+
         DB::insert('INSERT INTO dashboard_rating (id, category, min_rating, max_rating) VALUES (?, ?, ?, ?)', [3, 'RED', 0, 0.5]);
     }
 }


### PR DESCRIPTION
I found a bug in dashboard when I am doing testing in my local Linux env.

For a newly created portfolio with a newly created project, I assess red flag and principles with score 1.9 or 2.0.
In dashboard, the principle summary for this portfolio not showing rating properly.

I suspect there may be something different about stored proc / function deployment in database in docker image....
P.S. I manually deployed stored proc / function in TablePlus due to permission issue before...

I did same testing in local Windows env, but it works properly. Principle summary can be showed correctly.

Suddenly I recall that dashboard_rating.max_rating for GREEN record needs to change to a value > 2.0, e.g. 2.01.
This is to include principles scored 2.0. I update it in TablePlus then principle rating works properly in dashboard.

This PR contains a minor change with comments in Seeder file only.

---

Screen shots:

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/0b51cd39-1043-4812-8125-c80bec819eea)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/e7ca4f76-69ff-48bd-b559-f59b9808af9e)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/569ca2c4-e133-4a3a-9551-c994c3f2b106)


