### PR TITLE
always order institution types by admin-set ordering

### DIFF
--- a/app/Models/InitiativeCategory.php
+++ b/app/Models/InitiativeCategory.php
@@ -18,6 +18,13 @@ class InitiativeCategory extends Model
     protected $table = 'initiative_categories';
     protected $guarded = ['id'];
 
+    protected static function booted()
+    {
+        static::addGlobalScope('ordering', function (Builder $builder) {
+            $builder->orderBy('lft');
+        });
+    }
+
 
     public function projects(): HasMany
     {

--- a/app/Models/InstitutionType.php
+++ b/app/Models/InstitutionType.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -19,6 +20,13 @@ class InstitutionType extends Model
 
     protected $table = 'institution_types';
     protected $guarded = ['id'];
+
+    protected static function booted()
+    {
+        static::addGlobalScope('ordering', function (Builder $builder) {
+             $builder->orderBy('lft');
+        });
+    }
 
     public function organisations(): HasMany
     {


### PR DESCRIPTION
When "reordering" institution types on the admin panel (`/admin/institution-type`), the order set in re-ordering was not reflected in how they are displayed throughout the site. 

This PR fixes that issue by adding an `orderBy` global scope. 

It does the same for `InitiativeCateogry`. 

