### PR TITLE
FIX: skip division if no additional criteria exist

### DIFF
--- a/app/Models/Assessment.php
+++ b/app/Models/Assessment.php
@@ -226,6 +226,11 @@ class Assessment extends Model
     // get additional criteria score if relevant
     public function getAdditionalScoreAttribute(): ?int
     {
+
+        if(!$this->project->organisation->has_additional_criteria || $this->project->organisation->additionalCriteria->count() === 0) {
+            return null;
+        }
+
         if($this->additional_status === AssessmentStatus::Complete->value) {
             $additionalCriteria = $this->additionalCriteria;
 


### PR DESCRIPTION
Bug report from user - when accessing the main organisation's 'show' page, they get a 500 error "division by zero". 

Stack trace showed this as coming from the `Assessment` class => `getAdditionalScoreAttribute()`. It was assuming there was at least 1 additional criteria, even though the organisation in question doesn't have any. 

I added a check to make sure the organisation is using additional criteria and that there is at least 1 additionalCriteria entry for the organisation to fix the issue. 

**Screenshot**
![CleanShot 2023-11-15 at 11 34 24](https://github.com/stats4sd/aec_portfolio/assets/5711101/12401cbc-4526-41d7-b66b-9ff2055031ad)
