### PR TITLE
fix for odd telecope-y bug?

### DIFF
--- a/app/Models/Assessment.php
+++ b/app/Models/Assessment.php
@@ -227,7 +227,7 @@ class Assessment extends Model
     public function getAdditionalScoreAttribute(): ?int
     {
 
-        if(!$this->project->organisation->has_additional_criteria || $this->project->organisation->additionalCriteria->count() === 0) {
+        if(!$this->project?->organisation->has_additional_criteria || $this->project?->organisation->additionalCriteria->count() === 0) {
             return null;
         }
 


### PR DESCRIPTION
The stack-trace on this one was odd. It looks like the system was trying to json_serialise an empty assessment? So there was no project (because there was no data yet), but it was still trying to calculate the variables defined in `$appends`. 

I have no idea why, but making the project optional with `?` works. Now, if there is ever *not* a project set, the additional_score attribute will return null. 

