### PR TITLE
Add Existing User to Institution Directly

### DIFF
--- a/app/Mail/AddMemberConfirmed.php
+++ b/app/Mail/AddMemberConfirmed.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Invite;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class AddMemberConfirmed extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $inviterName;
+    public $inviterEmail;
+    public $organisationName;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($inviterName, $inviterEmail, $organisationName)
+    {
+        $this->inviterName = $inviterName;
+        $this->inviterEmail = $inviterEmail;
+        $this->organisationName = $organisationName;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from(config('mail.from.address'))
+        ->subject(config('app.name'). ': Invitation To Join Institution ' . $this->organisationName)
+        ->markdown('emails.invite_confirmed');
+    }
+}

--- a/resources/views/emails/invite.blade.php
+++ b/resources/views/emails/invite.blade.php
@@ -2,7 +2,7 @@
 
 {{ $invite->inviter->name }} ({{ $invite->inviter->email }}) has invited you to join the following institution on the {{ config('app.name') }}.
 
-**Team:** {{ $invite->organisation->name }}
+**Institution:** {{ $invite->organisation->name }}
 
 Click the link below to register on the platform. If you use the same email address, you will be automatically added to the institution after registration.
 

--- a/resources/views/emails/invite_confirmed.blade.php
+++ b/resources/views/emails/invite_confirmed.blade.php
@@ -1,0 +1,16 @@
+@component('mail::message')
+
+{{ $inviterName }} ({{ $inviterEmail }}) has invited you to join the following institution on the {{ config('app.name') }}.
+
+**Institution:** {{ $organisationName }}
+
+As you are an existing user on the platform, no registration is required.
+You have been added to {{ $organisationName }} directly.
+
+If you have been sent this email by mistake, please ignore this message.
+
+Best regards,<br>
+Site Admin,<br>
+{{ config('app.name') }}
+
+@endcomponent


### PR DESCRIPTION
### *** NOTE ***

There is a minor change to add a flag to indicate "contribute to funding flow" in portfolio level.
The program change is committed to dev branch accidentally.
This minor change will be reviewed when we create a PR for live env deployment. That PR will include all delta changes between dev branch and main branch.

---

This PR is submitted to add existing user to institution directly.

This PR contains below changes in backend:
1. For email address not existed in existing users, use original workflow to send email invitation.
2. For email address that existed in existing users, do below if user not belong to the institution
  2.1 Send email confirmation instead of email invitation, it is not required to register again
  2.2 Add role_invites record for reference purpose
  2.3 Add organisation_members record, user will be added to institution immediately

---

Potential Change:

There are three possible roles for institutional user: 
 - Institutional Admin
 - Institutional Assessor
 - Institutional Member

The user role is defined in user account level now. (i.e. model_has_roles table) 
This is not defined in institution member level. (i.e. organisation_members)

In other words, one login account can have one role only.
For example:
1. New user A has been invited to join institution Stats4SD as Institutional Assesser
2. New user A registered login account, system assigned role Institutional Assesser to user A
3. Existing user A has been invited to join institution ICRAF as another role, e.g. Institutional Member
4. Existing user A will be added to institution ICRAF directly, but the role is Institutional Assesser instead of Institutional Member

In Invite members page, when we fill in an email address for an existing user, the selected role will have no effect.
This is not ideal, but I am not sure whether this PR is now good enough to fulfill user's need at this moment.

---

If we need to support different role in different institution, more refinement work and testings are required. E.g.
1. Move role from table model_has_roles to organisation_members
2. Play around with Backpack permission manager, probably it may not be very straight forward to do our required change
3. Prepare data migration for existing users in live env

I would recommend:
1. Check whether institution level role is required or not
2. If it is required, can we do it in version 2.0?