### PR TITLE
Dashboard - Exclude Non Funding Flow Initiatives

### DIFF
--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -121,11 +121,14 @@ BEGIN
     SET @SQLText = CONCAT(@SQLText, ' INSERT INTO dashboard_project (dashboard_id, project_id)');
     SET @SQLText = CONCAT(@SQLText, ' SELECT ', dashboardYoursId, ', p.id');
     SET @SQLText = CONCAT(@SQLText, ' FROM projects p');
+    SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN portfolios po');
+    SET @SQLText = CONCAT(@SQLText, ' ON p.portfolio_id = po.id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN project_region pr');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = pr.project_id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN country_project cp');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = cp.project_id');
     SET @SQLText = CONCAT(@SQLText, ' WHERE p.deleted_at IS NULL');
+    SET @SQLText = CONCAT(@SQLText, ' AND po.contributes_to_funding_flow = 1');
 
 
     -- criteria
@@ -196,11 +199,14 @@ BEGIN
     SET @SQLText = CONCAT(@SQLText, ' INSERT INTO dashboard_project (dashboard_id, project_id)');
     SET @SQLText = CONCAT(@SQLText, ' SELECT ', dashboardOthersId, ', p.id');
     SET @SQLText = CONCAT(@SQLText, ' FROM projects p');
+    SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN portfolios po');
+    SET @SQLText = CONCAT(@SQLText, ' ON p.portfolio_id = po.id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN project_region pr');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = pr.project_id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN country_project cp');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = cp.project_id');
     SET @SQLText = CONCAT(@SQLText, ' WHERE p.deleted_at IS NULL');
+    SET @SQLText = CONCAT(@SQLText, ' AND po.contributes_to_funding_flow = 1');
 
 
     -- criteria

--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -120,7 +120,7 @@ BEGIN
     SET @SQLText = '';
     SET @SQLText = CONCAT(@SQLText, ' INSERT INTO dashboard_project (dashboard_id, project_id)');
     SET @SQLText = CONCAT(@SQLText, ' SELECT ', dashboardYoursId, ', p.id');
-    SET @SQLText = CONCAT(@SQLText, ' ON p.portfolio_id = po.id');
+    SET @SQLText = CONCAT(@SQLText, ' FROM projects p');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN project_region pr');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = pr.project_id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN country_project cp');

--- a/database/procedures/generate_dashboard_summary.sql
+++ b/database/procedures/generate_dashboard_summary.sql
@@ -120,15 +120,12 @@ BEGIN
     SET @SQLText = '';
     SET @SQLText = CONCAT(@SQLText, ' INSERT INTO dashboard_project (dashboard_id, project_id)');
     SET @SQLText = CONCAT(@SQLText, ' SELECT ', dashboardYoursId, ', p.id');
-    SET @SQLText = CONCAT(@SQLText, ' FROM projects p');
-    SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN portfolios po');
     SET @SQLText = CONCAT(@SQLText, ' ON p.portfolio_id = po.id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN project_region pr');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = pr.project_id');
     SET @SQLText = CONCAT(@SQLText, ' LEFT JOIN country_project cp');
     SET @SQLText = CONCAT(@SQLText, ' ON p.id = cp.project_id');
     SET @SQLText = CONCAT(@SQLText, ' WHERE p.deleted_at IS NULL');
-    SET @SQLText = CONCAT(@SQLText, ' AND po.contributes_to_funding_flow = 1');
 
 
     -- criteria


### PR DESCRIPTION
This PR is submitted for fix #244.

This PR contains one change:
1. Dashboard, to exclude initiatives in portfolios that are not contributing to funding flow

---

In dashboard, we get initatives regardless whether it's portfolio is contributing to funding flow or not.
I assume it will be the default way for getting initiatives in dashboard for comparison. Therefore I added a condition in stored procedure related SELECT SQL directly. If we add a new filter in dashboard Vue component, user will need to select it everytime.

Um... probably we can add a new filter selection box, with 3 options:
1. Contribute to funding flow
2. Not contribute to funding flow
3. All

I am not quite sure whether it will increase complexity and create possible confusion. So... I stick with the current approach first.