### PR TITLE
Fix Header Layout Issue

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -25,7 +25,7 @@ body {
 }
 
 .app-header {
-    height: 100px !important;
+    height: 200px !important;
     flex-basis: 100px !important;
 }
 

--- a/resources/views/vendor/backpack/base/inc/menu.blade.php
+++ b/resources/views/vendor/backpack/base/inc/menu.blade.php
@@ -12,7 +12,7 @@
 </ul>
 <!-- ========== End of top menu left items ========== -->
 
-<ul class="nav navbar-nav ml-auto mr-auto d-flex">
+<ul class="nav navbar-nav ml-auto mr-0 d-flex">
     <li class="nav-item mx-3 font-weight-bold"><a class="nav-link text-deep-green" href="{{ backpack_url('dashboard') }}">Dashboard</a>
         </li>
     <li class="nav-item mx-3 font-weight-bold"><a class="nav-link text-deep-green" href="{{ backpack_url('organisation/show') }}">My Institution</a>
@@ -25,7 +25,7 @@
 <!-- ========================================================= -->
 <!-- ========= Top menu right items (ordered right) ========== -->
 <!-- ========================================================= -->
-<ul class="nav navbar-nav ml-auto @if(config('backpack.base.html_direction') == 'rtl') mr-0 @endif">
+<ul class="nav navbar-nav ml-auto mr-0">
     @if (backpack_auth()->guest())
         <li class="nav-item"><a class="nav-link" href="{{ route('backpack.auth.login') }}">{{ trans('backpack::base.login') }}</a>
         </li>


### PR DESCRIPTION
This PR is submitted to fix #233.

This PR contains below changes:
1. nav bar 1, remove space at right hand side
2. nav bar 2, remove space at right hand side
3. header shadow, change height from 100 to 200, make enough space for nav bars showed in 2 lines

This is to make sure header shadow should be showed properly no matter nav bars are showed in 1 line or 2 lines.

---

Screen shots: 

BEFORE and AFTER for different screen size

BEFORE
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/fa4ec972-3928-44b1-ba94-7ed03c97ab12)

AFTER
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/4dc5f826-12c7-43dc-b78e-eabf1ead4d9c)

---

BEFORE
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/ce2616bd-de35-4603-86d6-7c846a3d974d)

AFTER
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/3ba887c6-6e22-4446-a180-700763e5e2a4)

---

BEFORE
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/d4e6c9fb-0bf5-451d-9416-6461419ee51a)

AFTER
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/53d50997-1fbb-40f7-83aa-1d56aaaee10d)

