### PR TITLE
Add Database Log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,6 @@ ADMIN_PASSWORD=password
 
 # Laravel Flare
 FLARE_KEY=
+
+# Database log level
+DB_LOG_LEVEL=ERROR

--- a/app/Console/Commands/GetExchangeRatesForOneDay.php
+++ b/app/Console/Commands/GetExchangeRatesForOneDay.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Carbon\Carbon;
+use App\Services\DBLog;
 use App\Models\Currency;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -30,6 +31,8 @@ class GetExchangeRatesForOneDay extends Command
      */
     public function handle()
     {
+        DBLog::info('GetExchangeRatesForOneDay', 'SYSTEM', 'start');
+
         // get yesterday date
         $date = Carbon::now()->subDays(1)->toDateString();
 
@@ -41,10 +44,11 @@ class GetExchangeRatesForOneDay extends Command
         foreach ($currencies as $currency) {
             GetOneDayExchangeRates::dispatch($currency, $date);
             $this->comment('dispatched job for ' . $currency . ' and the date ' . $date);
+            DBLog::debug('GetExchangeRatesForOneDay', 'SYSTEM', 'dispatched job for ' . $currency . ' and the date ' . $date);
         }
 
         $this->info('done!');
 
+        DBLog::info('GetExchangeRatesForOneDay', 'SYSTEM', 'end');
     }
-
 }

--- a/app/Models/SystemLog.php
+++ b/app/Models/SystemLog.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Model;
+
+class SystemLog extends Model
+{
+    use CrudTrait;
+
+    protected $table = 'system_logs';
+    protected $guarded = ['id'];
+}

--- a/app/Services/DBLog.php
+++ b/app/Services/DBLog.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SystemLog;
+use Illuminate\Support\Str;
+
+class DBLog
+{
+    public static $logLevels = array('FATAL', 'ERROR', 'WARN', 'INFO', 'DEBUG');
+
+    public static function log(string $level, string $program, string $createdBy, string $message)
+    {
+        $systemLogLevel = Str::upper(env('DB_LOG_LEVEL', 'ERROR'));
+        $systemLogLevelNumber = array_search($systemLogLevel, DBLog::$logLevels);
+        $logLevelNumber = array_search($level, DBLog::$logLevels);
+
+        if ($logLevelNumber <= $systemLogLevelNumber) {
+            SystemLog::create([
+                'level' => $level,
+                'program' => $program,
+                'created_by' => $createdBy,
+                'message' => $message,
+            ]);
+        }
+    }
+
+    public static function fatal(string $program, string $createdBy, string $message)
+    {
+        DBLog::log('FATAL', $program, $createdBy, $message);
+    }
+
+    public static function error(string $program, string $createdBy, string $message)
+    {
+        DBLog::log('ERROR', $program, $createdBy, $message);
+    }
+
+    public static function warn(string $program, string $createdBy, string $message)
+    {
+        DBLog::log('WARN', $program, $createdBy, $message);
+    }
+
+    public static function info(string $program, string $createdBy, string $message)
+    {
+        DBLog::log('INFO', $program, $createdBy, $message);
+    }
+
+    public static function debug(string $program, string $createdBy, string $message)
+    {
+        DBLog::log('DEBUG', $program, $createdBy, $message);
+    }
+}

--- a/database/migrations/2024_03_11_104041_create_system_logs_table.php
+++ b/database/migrations/2024_03_11_104041_create_system_logs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('system_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('level')->index();
+            $table->string('program')->index();
+            $table->string('message');
+            $table->string('created_by');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('system_logs');
+    }
+};


### PR DESCRIPTION
This PR is submitted to help resolving issue for exchange rate retrieval.

This PR contains below changes:
1. Add log message in database level to trace program executed by schedule job and queue
2. Add configuration in .env, make it flexible to turn on / turn off database log feature

---

Testing in local env:

When QUEUE_CONNECTION=sync
 - only first 5 currencies exchange rate retrieved (33 * 5 = 165 records).
 - no new records in jobs table

When QUEUE_CONNECTION=database
 - system_logs table is empty
 - jobs table is empty
 - at the beginning, handle first 5 currencies
 - after each minute, handled another 5 currencies
 - finally 33 currencies exchange rate data retrieved (33 * 33 = 1089)

---

Possible casue in live env:
 - 1650 jobs accumulated (1650 / 33 = 50 days), we may need to clear all jobs before deploying this PR

Screen shot:

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/f84bba24-28ca-49fe-8295-605e82d5e18a)

