### PR TITLE
Fix Dashboard Unexpected Message

### DIFF
--- a/app/Http/Controllers/GenericDashboardController.php
+++ b/app/Http/Controllers/GenericDashboardController.php
@@ -288,27 +288,12 @@ class GenericDashboardController extends Controller
             ->whereHas('assessments', function (Builder $query) {
                 $query->where('redline_status', AssessmentStatus::Failed->value)
                     ->orWhere('principle_status', AssessmentStatus::Complete->value);
-
-                // id: 574, 737 are "Not Started", not "Complete"
-                // $query->where('redline_status', AssessmentStatus::Complete->value);
-
-                // $query->where('redline_status', 'Complete')
-                //     ->where('id', '<>', 574)
-                //     ->where('id', '<>', 737);
             })
             ->get()
             ->pluck('assessments')
             ->flatten();
 
-        //££
-        logger("==========");
-        logger('count($allAssessments): ' . count($allAssessments));
-        $allAssessmentsId = $allAssessments->pluck('id');
-        logger($allAssessmentsId);
-        //££
-
         $allAssessmentsYours = $allAssessments->whereIn(
-            // 'id',
             'project_id',
             DB::table('dashboard_project')
                 ->select('project_id')
@@ -318,16 +303,7 @@ class GenericDashboardController extends Controller
                 ->toArray()
         );
 
-        //££
-        logger("++++++++++");
-        logger('$dashboardYoursId: ' . $dashboardYoursId);
-        logger('count($allAssessmentsYours): ' . count($allAssessmentsYours));
-        $allAssessmentsYoursId = $allAssessmentsYours->pluck('id');
-        logger($allAssessmentsYoursId);
-        //££
-
         $allAssessmentsOthers = $allAssessments->whereIn(
-            // 'id',
             'project_id',
             DB::table('dashboard_project')
                 ->select('project_id')
@@ -336,14 +312,6 @@ class GenericDashboardController extends Controller
                 ->pluck('project_id')
                 ->toArray()
         );
-
-        //££
-        logger("++++++++++");
-        logger('$dashboardYoursId: ' . $dashboardYoursId);
-        logger('count($allAssessmentsYours): ' . count($allAssessmentsOthers));
-        $allAssessmentsOthersId = $allAssessmentsOthers->pluck('id');
-        logger($allAssessmentsOthersId);
-        //££
 
 
         $noOfInitiativeCompletedAssessment = $allAssessmentsYours->count();

--- a/app/Http/Controllers/GenericDashboardController.php
+++ b/app/Http/Controllers/GenericDashboardController.php
@@ -293,6 +293,15 @@ class GenericDashboardController extends Controller
             ->pluck('assessments')
             ->flatten();
 
+        // find latest assessment id for all projects
+        $latestAssessmentIds = Assessment::select(DB::raw('MAX(id) as id'))
+            ->groupBy('project_id')
+            ->get()
+            ->pluck('id');
+
+        // only keep latest assessment from all assessments, previously completed assessments will be removed
+        $allAssessments = $allAssessments->whereIn('id', $latestAssessmentIds);
+
         $allAssessmentsYours = $allAssessments->whereIn(
             'project_id',
             DB::table('dashboard_project')


### PR DESCRIPTION
This PR is submitted to fix an uinexpected message in dashboard.

Root cause identified:
Incorrect column used in query. In whereIn() clause, the column should be "project_id" instead of "id".
The fix has been applied to both $allAssessmentsYours and $allAssessmentsOthers.

```
$allAssessmentsYours = $allAssessments->whereIn(
            'project_id',
            DB::table('dashboard_project')
                ->select('project_id')
                ->where('dashboard_id', $dashboardYoursId)
                ->get()
                ->pluck('project_id')
                ->toArray()
        );
```

---

Screen shots

BEFORE:

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/32a3b049-44ac-4610-946d-d0014a1759cb)

AFTER:

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/f6a3d83f-e3d3-429d-a157-46b03f31ac59)
