### PR TITLE
Fix User Support Issue

### DIFF
--- a/resources/js/components/UserFeedbackForm.vue
+++ b/resources/js/components/UserFeedbackForm.vue
@@ -87,7 +87,7 @@
 
 <script setup>
 
-import {ref, watch} from "vue";
+import {ref, watch, onMounted} from "vue";
 import 'vue-select/dist/vue-select.css'
 import vSelect from "vue-select";
 import Swal from "sweetalert2";
@@ -104,6 +104,10 @@ const props = defineProps({
 
 const errors = ref({})
 const form = ref({})
+
+onMounted(() => {
+    includeDetails.value = true;
+})
 
 async function save() {
     try {
@@ -122,7 +126,7 @@ async function save() {
 
         // reset form
         form.value = {}
-        includeDetails.value = false;
+        includeDetails.value = true;
         mediaCollectionComponent.value.mediaLibrary.state.media = [];
 
 
@@ -153,5 +157,6 @@ function changeMedia(media) {
 
     console.log(mediaCollectionComponent.value.mediaLibrary)
 }
+
 
 </script>

--- a/resources/views/organisations/portfolios.blade.php
+++ b/resources/views/organisations/portfolios.blade.php
@@ -1,12 +1,13 @@
 <div class="card-header">
     <div class="d-flex align-items-center">
         <h2 class="mb-0">Institution Portfolios</h2>
-        <x-help-text-link class="font-2xl" location="My Institution - Portfolios"/>
     </div>
     <p class="help-block">Review and manage the list of portfolios. All initiatives entered into the platform are part of a portfolio.
     </p>
 
-    <x-help-text-entry location="My Institution - Portfolios"/>
+    <p>
+        Every institution needs at least one portfolio. A portfolio is a set of initiatives, but beyond that we have deliberately left the definition of a portfolio broad, so it can fit your institution's existing method of grouping initiatives. For smaller institutions with only a few initiatives, you can choose to have 1 single portfolio if you wish.
+    </p>
 
 
 </div>
@@ -15,76 +16,76 @@
 
     <table class="table table-striped">
         <thead>
-        <tr>
-            <th scope="col">Portfolio Name</th>
-            <th scope="col">Budget</th>
-            <th scope="col">Description</th>
-            <th scope="col">Contributes to Funding Flow Analysis</th>
-            <th scope="col"># of Initiatives</th>
-            <th scope="col"># of Fully Assessed Initiatives</th>
-            <th scope="col">Actions</th>
-        </tr>
+            <tr>
+                <th scope="col">Portfolio Name</th>
+                <th scope="col">Budget</th>
+                <th scope="col">Description</th>
+                <th scope="col">Contributes to Funding Flow Analysis</th>
+                <th scope="col"># of Initiatives</th>
+                <th scope="col"># of Fully Assessed Initiatives</th>
+                <th scope="col">Actions</th>
+            </tr>
         </thead>
         <tbody>
-        @if(Auth::user()->can('view portfolios'))
+            @if(Auth::user()->can('view portfolios'))
             @foreach($organisation->portfolios as $portfolio)
-                <tr>
-                    <td>
-                        {{ $portfolio->name }}
-                    </td>
-                    <td>{{ $organisation->currency }} {{ $portfolio->budget }}</td>
-                    <td>{{ $portfolio->description }}</td>
-                    <td>{{ $portfolio->fundingFlowAnalysis }}</td>
-                    <td>{{ $portfolio->projects->count() }}</td>
-                    <td>{{ $portfolio->projects->filter(fn(\App\Models\Project $initiative): bool => $initiative->latest_assessment->completed)->count() }}</td>
-                    <td>
-                        <div class="btn-group text-nowrap">
+            <tr>
+                <td>
+                    {{ $portfolio->name }}
+                </td>
+                <td>{{ $organisation->currency }} {{ $portfolio->budget }}</td>
+                <td>{{ $portfolio->description }}</td>
+                <td>{{ $portfolio->fundingFlowAnalysis }}</td>
+                <td>{{ $portfolio->projects->count() }}</td>
+                <td>{{ $portfolio->projects->filter(fn(\App\Models\Project $initiative): bool => $initiative->latest_assessment->completed)->count() }}</td>
+                <td>
+                    <div class="btn-group text-nowrap">
 
-                            <a href="{{ url("admin/project?portfolioFilter=$portfolio->name") }}" class="btn btn-success btn-sm">SHOW INITIATIVES</a>
-                            @if(Auth::user()->can('maintain portfolios'))
-                                <a href="{{ route('portfolio.edit', [$portfolio]) }}" class="btn btn-info btn-sm">EDIT</a>
-                                <button class="btn btn-danger btn-sm remove-button" data-portfolio="{{ $portfolio->id }}" data-toggle="modal" data-target="#removePortfolioModal{{ $portfolio->id }}">REMOVE</button>
-                            @endif
-                        </div>
-                    </td>
-                </tr>
+                        <a href="{{ url("admin/project?portfolioFilter=$portfolio->name") }}" class="btn btn-success btn-sm">SHOW INITIATIVES</a>
+                        @if(Auth::user()->can('maintain portfolios'))
+                        <a href="{{ route('portfolio.edit', [$portfolio]) }}" class="btn btn-info btn-sm">EDIT</a>
+                        <button class="btn btn-danger btn-sm remove-button" data-portfolio="{{ $portfolio->id }}" data-toggle="modal" data-target="#removePortfolioModal{{ $portfolio->id }}">REMOVE</button>
+                        @endif
+                    </div>
+                </td>
+            </tr>
             @endforeach
-        @endif
+            @endif
         </tbody>
     </table>
-    <hr/>
+    <hr />
 
     @if(Auth::user()->can('maintain portfolios'))
-        <a class="btn btn-dark mt-5" href="{{ route('portfolio.create') }}">Add Portfolio</a>
+    <a class="btn btn-dark mt-5" href="{{ route('portfolio.create') }}">Add Portfolio</a>
     @endif
 </div>
 
 
 @push('after_scripts')
-    @foreach($organisation->portfolios as $portfolio)
-        <div class="modal fade" id="removePortfolioModal{{ $portfolio->id }}" tabindex="-1" role="dialog" aria-labelledby="removeUserModalLabel{{ $portfolio->id }}" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="removeUserModalLabel{{ $portfolio->id }}">Remove {{ $portfolio->email }} from {{ $organisation->name }}</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        Are you sure you wish to remove {{ $portfolio->name }} from {{ $organisation->name }}?<br/><br/>
-                        <span class="font-weight-bold text-danger">This will delete all initiatives that are part of this portfolio!</span>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                        <form action="{{ route('portfolio.destroy', [$portfolio]) }}" method="POST">
-                            @csrf
-                            @method('delete')
-                            <button type="submit" class="btn btn-primary">Confirm Remove</button>
-                        </form>
-                    </div>
-                </div>
+@foreach($organisation->portfolios as $portfolio)
+<div class="modal fade" id="removePortfolioModal{{ $portfolio->id }}" tabindex="-1" role="dialog" aria-labelledby="removeUserModalLabel{{ $portfolio->id }}" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="removeUserModalLabel{{ $portfolio->id }}">Remove {{ $portfolio->email }} from {{ $organisation->name }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                Are you sure you wish to remove {{ $portfolio->name }} from {{ $organisation->name }}?<br /><br />
+                <span class="font-weight-bold text-danger">This will delete all initiatives that are part of this portfolio!</span>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <form action="{{ route('portfolio.destroy', [$portfolio]) }}" method="POST">
+                    @csrf
+                    @method('delete')
+                    <button type="submit" class="btn btn-primary">Confirm Remove</button>
+                </form>
             </div>
         </div>
-    @endforeach
+    </div>
+</div>
+@endforeach
 @endpush


### PR DESCRIPTION
This PR is submitted to fix #265

This PR contains below changes:
1. If the "anonymise" option is ticked, column user_feedbacks.user_id should be null. To make sure we are doing what we do.
   - I cannot replicate this issue in local env. column user_feedbacks.user_id is null when "anonymise" option is ticked
   - Maybe we have this bug in early stage, and then we fixed it but it has not been deployed to live env yet
2. By default, user support request should untick the "anonymise" option.
3. My Institution > Portfolio > Help text for "Institution Portfolios", we should show the help text all the time. To increase the possibility that user to read it.

---

Screen shots:
![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/a4608701-2041-4fe1-80eb-427db4438c4f)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/f396b2f3-2d60-474c-9ae1-d9efc65837df)

![image](https://github.com/stats4sd/aec_portfolio/assets/86968034/0974bfd1-11ac-4f1c-8aae-3b364c715ad0)
