### PR TITLE
Add duplicate initiative feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 yarn-error.log
 .idea
 .DS_Store
+data.ms/

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -520,6 +520,7 @@ class ProjectCrudController extends CrudController
                 $principleAssessment->customScoreTags->each(function (CustomScoreTag $customScoreTag) use ($newPrincipleAssessment) {
                     unset($customScoreTag->id);
                     unset($customScoreTag->principle_assessment_id);
+                    $customScoreTag->assessment_id = $newPrincipleAssessment->assessment_id;
 
                     $newPrincipleAssessment->customScoreTags()->create($customScoreTag->toArray());
                 });
@@ -546,6 +547,8 @@ class ProjectCrudController extends CrudController
                 $additionalCriteriaAssessment->customScoreTags->each(function (AdditionalCriteriaCustomScoreTag $customScoreTag) use ($newAdditionalCriteriaAssessment) {
                     unset($customScoreTag->id);
                     unset($customScoreTag->additional_criteria_assessment_id);
+
+                    $customScoreTag->assessment_id = $newAdditionalCriteriaAssessment->assessment_id;
 
                     $newAdditionalCriteriaAssessment->customScoreTags()->create($customScoreTag->toArray());
                 });

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Exports\InitiativeImportTemplate\InitiativeImportTemplateExportWorkbook;
 use App\Imports\ProjectWorkbookImport;
+use App\Models\AdditionalCriteria;
 use App\Models\AdditionalCriteriaAssessment;
 use App\Models\AdditionalCriteriaCustomScoreTag;
 use App\Models\FundingSource;
@@ -551,17 +552,6 @@ class ProjectCrudController extends CrudController
 
             });
 
-            $additionalCriteriaWithPivot = $assessment->additionalCriteria->mapWithKeys(function (AdditionalCriteriaScoreTag $additionalCriteria) {
-                return [
-                    $additionalCriteria->id => [
-                        'rating' => $additionalCriteria->pivot->rating,
-                        'rating_comment' => $additionalCriteria->pivot->rating_comment,
-                        'is_na' => $additionalCriteria->pivot->is_na,
-                    ],
-                ];
-            });
-
-            $newAssessment->additionalCriteria()->sync($additionalCriteriaWithPivot->toArray());
 
         });
 

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -544,11 +544,11 @@ class ProjectCrudController extends CrudController
 
                 $additionalCriteriaAssessment->scoreTags()->sync($scoreTagsWithPivot);
 
-                $additionalCriteriaAssessment->customScoreTags->each(function (AdditionalCriteriaCustomScoreTag $customScoreTag) use ($newAssessment) {
+                $additionalCriteriaAssessment->customScoreTags->each(function (AdditionalCriteriaCustomScoreTag $customScoreTag) use ($newAdditionalCriteriaAssessment) {
                     unset($customScoreTag->id);
                     unset($customScoreTag->additional_criteria_assessment_id);
 
-                    $newAssessment->customScoreTags()->create($customScoreTag->toArray());
+                    $newAdditionalCriteriaAssessment->customScoreTags()->create($customScoreTag->toArray());
                 });
 
             });

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -514,8 +514,6 @@ class ProjectCrudController extends CrudController
                     ];
                 });
 
-                ray($scoreTagsWithPivot);
-
                 $newPrincipleAssessment->scoreTags()->sync($scoreTagsWithPivot->toArray());
 
                 $principleAssessment->customScoreTags->each(function (CustomScoreTag $customScoreTag) use ($newPrincipleAssessment) {

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -34,7 +34,7 @@ class ProjectRequest extends FormRequest
             'code' => ['nullable', 'string', new UniqueProjectCode],
             'description' => 'nullable|string',
             'initiativeCategory' => 'required|exists:initiative_categories,id',
-            'initiative_category_otther' => 'nullable',
+            'initiative_category_other' => 'nullable',
             'budget' => 'required|integer|gte:0',
             'currency' => 'required|max:3',
             'exchange_rate' => 'sometimes|required',

--- a/app/Models/Assessment.php
+++ b/app/Models/Assessment.php
@@ -35,7 +35,7 @@ class Assessment extends Model
 
             $org_has_additional_criteria = $assessment->project->organisation->has_additional_criteria;
 
-            if ($org_has_additional_criteria) {
+            if ($org_has_additional_criteria && !$assessment->additional_status) {
                 $assessment->additional_status = "Not Started";
             }
         });

--- a/app/Models/Assessment.php
+++ b/app/Models/Assessment.php
@@ -6,6 +6,7 @@ use App\Enums\AssessmentStatus;
 use Illuminate\Database\Eloquent\Model;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
@@ -89,7 +90,7 @@ class Assessment extends Model
             || $this->additionalCriteriaAssessment->some(fn(AdditionalCriteriaAssessment $entry) => count($entry->revisionHistory));
     }
 
-    public function getRevisionHistoryAttribute()
+    public function getRevisionHistoryAttribute(): \Illuminate\Support\Collection
     {
         return
             collect([
@@ -100,7 +101,7 @@ class Assessment extends Model
                 ->flatten();
     }
 
-    public function appendExtrasToRevision($item, $relation)
+    public function appendExtrasToRevision($item, $relation): \Illuminate\Support\Collection
     {
         return $item->revisionHistory->map(function (Revision $history) use ($item, $relation) {
             $history->relation = Str::lower(Arr::join(Str::ucsplit($relation), ' '));
@@ -110,8 +111,7 @@ class Assessment extends Model
         });
     }
 
-
-    public function project()
+    public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class)
             ->withoutGlobalScope('organisation');
@@ -127,7 +127,7 @@ class Assessment extends Model
         return $this->hasMany(AdditionalCriteriaCustomScoreTag::class);
     }
 
-    public function redLines()
+    public function redLines(): BelongsToMany
     {
         return $this->belongsToMany(RedLine::class)
             ->withPivot([
@@ -261,6 +261,14 @@ class Assessment extends Model
         return $this->hasMany(AdditionalCriteriaAssessment::class);
     }
 
+
+    public function scoreTags(): BelongsToMany
+    {
+        return $this->belongsToMany(ScoreTag::class, 'principle_assessment_score_tag', 'assessment_id', 'score_tag_id')
+            ->withPivot([
+                'principle_assessment_id'
+            ]);
+    }
 
     // Custom relationships to load scoreTags filtered by each of the 13 principles
     // hard-coded principles, so careful if we change our definition of AE!

--- a/app/Models/PrincipleAssessment.php
+++ b/app/Models/PrincipleAssessment.php
@@ -18,7 +18,7 @@ class PrincipleAssessment extends Model
     use CrudTrait;
     use RevisionableTrait;
 
-    protected $guarded = ['id', 'principle_id', 'assessment_id'];
+    protected $guarded = ['id', 'assessment_id'];
 
     public $table = 'principle_assessment';
 

--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return config('telescope.storage.database.connection');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('telescope_entries', function (Blueprint $table) {
+            $table->bigIncrements('sequence');
+            $table->uuid('uuid');
+            $table->uuid('batch_id');
+            $table->string('family_hash')->nullable();
+            $table->boolean('should_display_on_index')->default(true);
+            $table->string('type', 20);
+            $table->longText('content');
+            $table->dateTime('created_at')->nullable();
+
+            $table->unique('uuid');
+            $table->index('batch_id');
+            $table->index('family_hash');
+            $table->index('created_at');
+            $table->index(['type', 'should_display_on_index']);
+        });
+
+        $schema->create('telescope_entries_tags', function (Blueprint $table) {
+            $table->uuid('entry_uuid');
+            $table->string('tag');
+
+            $table->primary(['entry_uuid', 'tag']);
+            $table->index('tag');
+
+            $table->foreign('entry_uuid')
+                ->references('uuid')
+                ->on('telescope_entries')
+                ->onDelete('cascade');
+        });
+
+        $schema->create('telescope_monitoring', function (Blueprint $table) {
+            $table->string('tag')->primary();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('telescope_entries_tags');
+        $schema->dropIfExists('telescope_entries');
+        $schema->dropIfExists('telescope_monitoring');
+    }
+};

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Enums\GeographicalReach;
+use App\Models\Continent;
 use App\Models\Organisation;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -49,10 +50,37 @@ class TestSeeder extends Seeder
             'code' => 'TP1',
             'description' => 'A project for testing',
             'budget' => '1000000',
+            'budget_eur' => '1000000',
+            'budget_org' => '1000000',
+            'exchange_rate_eur' => 1,
             'exchange_rate' => 1,
             'currency' => 'EUR',
             'start_date' => '2023-01-01',
             'geographic_reach' => GeographicalReach::Global->name,
+            'main_recipient' => 'Test Recipient',
+            'initiative_category_id' => 1,
+            'sub_regions' => 'Test Sub Region',
+        ]);
+
+        $continents = Continent::take(2);
+        $regions = $continents->first()->regions()->take(2);
+        $countries = $regions->first()->countries()->take(4);
+
+        $initiative->continents()->sync($continents->pluck('id'));
+        $initiative->regions()->sync($regions->pluck('id'));
+        $initiative->countries()->sync($countries->pluck('id'));
+
+        $donorInstitution = Organisation::create([
+            'name' => 'Test Donor 1',
+            'geographic_reach' => GeographicalReach::Global->value,
+            'currency' => 'EUR',
+            'has_additional_criteria' => 0,
+            'description' => 'This is a test donor organisation',
+        ]);
+
+        $initiative->fundingSources()->createMany([
+            ['source' => 'Funding Source 1', 'amount' => 500000],
+            ['institution_id' => $donorInstitution->id, 'amount' => 500000],
         ]);
 
         $user1->organisations()->sync([$institution->id]);

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -72,7 +72,7 @@ class TestSeeder extends Seeder
 
         $donorInstitution = Organisation::create([
             'name' => 'Test Donor 1',
-            'geographic_reach' => GeographicalReach::Global->value,
+            'geographic_reach' => GeographicalReach::Global->name,
             'currency' => 'EUR',
             'has_additional_criteria' => 0,
             'description' => 'This is a test donor organisation',

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -57,21 +57,21 @@
                                 </div>
                             </div>
 
-                            <a class="btn btn-primary mr-2" :class="[ enableEditButton ? '' : 'disabled']"
+                            <a class="btn btn-primary mr-2 mb-2" :class="[ enableEditButton ? '' : 'disabled']"
                                :href="`/admin/project/${initiative.id}/edit`">Edit Details</a>
 
-                            <a class="btn btn-success mr-2" :class="[ enableShowButton ? '' : 'disabled']"
+                            <a class="btn btn-success mr-2 mb-2" :class="[ enableShowButton ? '' : 'disabled']"
                                :href="`/admin/project/${initiative.id}/show`">Show Information</a>
 
-                            <button class="btn btn-danger mr-2" :class="[ enableDeleteButton ? '' : 'disabled']"
+                            <button class="btn btn-danger mr-2 mb-2" :class="[ enableDeleteButton ? '' : 'disabled']"
                                     @click="enableDeleteButton ? removeInitiative() : '';">Delete
                             </button>
 
-                            <button class="btn btn-warning mr-2" :class="[ enableReassessButton ? (initiative.latest_assessment.principle_status === 'Complete' && initiative.latest_assessment.additional_status != 'Not Started' ? '' : 'disabled') : 'disabled']"
+                            <button class="btn btn-warning mr-2 mb-2" :class="[ enableReassessButton ? (initiative.latest_assessment.principle_status === 'Complete' && initiative.latest_assessment.additional_status != 'Not Started' ? '' : 'disabled') : 'disabled']"
                                     @click="enableReassessButton ? (initiative.latest_assessment.principle_status === 'Complete' && initiative.latest_assessment.additional_status != 'Not Started' ? reassessInitiative() : 'disabled') : '';">Reassess
                             </button>
 
-                            <button class="btn btn-warning" :class="[ enableDeleteButton ? '' : 'disabled']"
+                            <button class="btn btn-warning mr-2 mb-2" :class="[ enableDeleteButton ? '' : 'disabled']"
                                @click="enableDeleteButton ? duplicateInitiative() : '';">Duplicate</button>
 
                         </div>

--- a/resources/js/components/InitiativeListCard.vue
+++ b/resources/js/components/InitiativeListCard.vue
@@ -67,9 +67,12 @@
                                     @click="enableDeleteButton ? removeInitiative() : '';">Delete
                             </button>
 
-                            <button class="btn btn-warning" :class="[ enableReassessButton ? (initiative.latest_assessment.principle_status === 'Complete' && initiative.latest_assessment.additional_status != 'Not Started' ? '' : 'disabled') : 'disabled']"
+                            <button class="btn btn-warning mr-2" :class="[ enableReassessButton ? (initiative.latest_assessment.principle_status === 'Complete' && initiative.latest_assessment.additional_status != 'Not Started' ? '' : 'disabled') : 'disabled']"
                                     @click="enableReassessButton ? (initiative.latest_assessment.principle_status === 'Complete' && initiative.latest_assessment.additional_status != 'Not Started' ? reassessInitiative() : 'disabled') : '';">Reassess
                             </button>
+
+                            <button class="btn btn-warning" :class="[ enableDeleteButton ? '' : 'disabled']"
+                               @click="enableDeleteButton ? duplicateInitiative() : '';">Duplicate</button>
 
                         </div>
 
@@ -279,6 +282,29 @@ async function reassessInitiative() {
         // pass the refreshed initiative out to the list
         emit('refresh_initiative', result.data)
 
+    }
+}
+
+async function duplicateInitiative() {
+    let choice = await Swal.fire({
+        title: "Are you sure?",
+        text: "This initiative will be duplicated, along with any associated assessments, complete or in progress. You will be taken to the edit page for the new initiative.",
+        icon: "warning",
+        showCancelButton: true,
+        confirmButtonColor: "#3085d6",
+        cancelButtonColor: "#d33",
+        confirmButtonText: "Yes, duplicate it!",
+    });
+
+    if(choice.isConfirmed) {
+        let result = await axios.post(`/admin/project/${props.initiative.id}/duplicate`);
+
+        new Noty({
+            type: "success",
+            text: `You have successfully duplicated the initiative ${props.initiative.name}`,
+        }).show();
+
+        window.location.href = `/admin/project/${result.data.id}/edit`;
     }
 }
 

--- a/resources/js/components/InitiativesList.vue
+++ b/resources/js/components/InitiativesList.vue
@@ -142,9 +142,14 @@ const sortOptions = ref([
         label: 'Name',
     },
     {
+        id: 'code',
+        label: 'Code',
+    },
+    {
         id: 'budget_org',
         label: 'Budget',
-    }
+    },
+
 ])
 
 // default value for sortBy and sortDir, which is sorted by name in ascending order

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -105,6 +105,7 @@ Route::group([
         Route::crud('project', ProjectCrudController::class);
         Route::get('project', [ProjectController::class, 'index']);
         Route::post('project/{id}/reassess', [ProjectCrudController::class, 'reAssess']);
+        Route::post('project/{project}/duplicate', [ProjectCrudController::class, 'duplicate']);
 
         Route::post('session/store', [SessionController::class, 'store']);
         Route::post('session/reset', [SessionController::class, 'reset']);


### PR DESCRIPTION
fixes #274. 

This PR add the option for users to duplicate a project and all associated assessments/entries. This is to address times when a project gets an extension, and the user wants to associate the new budget with the date of the extension and not the date of the project start. 

### Duplicate Function
The duplicate function does the following:

- clones the Project entry;
- associates the clone with the Continent, Region and Country models from the original;
- clones all FundingSource entries that are linked to the original;
- clones all Assessment entries that are linked to the original.

For each new assessment:
- the cloned assessment is linked to the Redline, Principle and AdditionalCriteria; and all pivot values are copied over to ensure the cloned assessment results are identical. 
- the clones assessment is linked to the same set of ScoreTag entries as the original. 
- all CustomScoreTag and AdditionalCriteriaCustomScoreTag entries linked to the original are cloned (and linked to the cloned assessment).


The button is disabled using the same logic as the delete project option: 
- it is disabled if the organisation has not yet signed the data sharing agreement;
- it is disabled if the user does not have the ability to create or manage projects in the current organisation.

The duplicate function also checks that the user "can" create projects, based on the ProjectPoilicy class.

### Other updates

This PR also fixes #279 - it adds "code" as a sort option on the Initiative List page. 

