### PR TITLE
Fix Organisation Agreement Issue

### DIFF
--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -48,7 +48,6 @@ class OrganisationController extends Controller
             'countries' => $countries,
             'tab' => $tab,
         ]);
-
     }
 
     // can only be used when an organisation is selected in the current session
@@ -63,7 +62,9 @@ class OrganisationController extends Controller
             $validated['has_additional_criteria'] = false;
         }
 
-        if (isset($validated['agreement']) && !$organisation->agreement_signed_at) {
+        // Agreement should be signed only when it is not yet signed.
+        // Once it is signed, it is not necessary to sign again
+        if (isset($validated['agreement']) && $organisation->agreement_signed_at == null) {
             unset($validated['agreement']);
             $validated['agreement_signed_at'] = Carbon::now();
             $validated['signee_id'] = Auth::user()->id;
@@ -79,7 +80,6 @@ class OrganisationController extends Controller
             ],
             'signee',
         ]);
-
     }
 
     public function saved()
@@ -105,7 +105,6 @@ class OrganisationController extends Controller
             $timestamp = Carbon::now()->toDateTimeString();
 
             ExportOrgData::dispatch($organisation, $timestamp);
-
         }
 
         return 'done - queued';
@@ -123,5 +122,4 @@ class OrganisationController extends Controller
 
         return response('success', 200);
     }
-
 }


### PR DESCRIPTION
This PR is submitted to fix #293 

Suspected that error occurred when user updated organisation details without signing the agreement.
I tried to replicate the same error in local env but failed.

I also tried to replicate this error in staging env with below steps, but failed too...
  - perform testing in staging env
   - use organisation "Demo Institution" for testing
    - update organisations.agreement_signed_at and organisations.signee_id to null in backend database
      - in front end "My Institution" page, change institution name from "Demo Institution" to "Demo Institution a", click "Save" button
      - no error occurred
   - cannot replicate same issue in staging env

---

As error cannot be replicated yet (or I do not know how to replicate it...), I am not sure whether we need this PR to fix it.

Anyway, this PR can be a reference for future.