### PR TITLE
Enhance Required Fields

### DIFF
--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -193,8 +193,20 @@ class ProjectCrudController extends CrudController
 
         CRUD::field('name');
         CRUD::field('code')->hint('The code should uniquely identify the project within your institution\'s porfolio. Leave blank for an auto-generated code.');
+
         CRUD::field('initiativeCategory')->label('Select the initiative category.')
-            ->hint('Select the one that best matches. If none of the options fit, select "other".');
+            ->hint('Select the one that best matches. If none of the options fit, select "other".')
+            // add CSS class "form-group", background color changed to pink at the beginning, then it changed back to white.
+            // it proved that CSS classs can be applied to a specific form field
+            //
+            // add a CSS class to change background color of this form field.
+            // Note:
+            // 1. Background color applied to the background of select2 instead of select2 itself... Field label background has been changed too
+            // 2. CSS class bg-danger-subtle (i.e. pink color) is not available until Bootstrap v5.3 (we are not using Bootstrap v5.3 yet...)
+            //
+            ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
+
+
         CRUD::field('initiative_category_other')->label('Enter the "other" category of initiative.');
         CRUD::field('description')->hint('This is optional, but will help to provide context for the AE assessment');
 
@@ -344,7 +356,11 @@ class ProjectCrudController extends CrudController
             ->options([
                 0 => 'This initiative is <b>entirely</b> self-funded',
                 1 => 'This initiative has external funding sources',
-            ]);
+            ])
+            // add a CSS class to change background color of this form field.
+            // Note:
+            // 1. Background color applied to whole part of radio button, instead of radio button options only
+            ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
 
         CRUD::field('fundingSources')
             ->label('Funding Sources')

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -193,11 +193,8 @@ class ProjectCrudController extends CrudController
 
         CRUD::field('name');
         CRUD::field('code')->hint('The code should uniquely identify the project within your institution\'s porfolio. Leave blank for an auto-generated code.');
-
         CRUD::field('initiativeCategory')->label('Select the initiative category.')
             ->hint('Select the one that best matches. If none of the options fit, select "other".');
-
-
         CRUD::field('initiative_category_other')->label('Enter the "other" category of initiative.');
         CRUD::field('description')->hint('This is optional, but will help to provide context for the AE assessment');
 

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -195,17 +195,7 @@ class ProjectCrudController extends CrudController
         CRUD::field('code')->hint('The code should uniquely identify the project within your institution\'s porfolio. Leave blank for an auto-generated code.');
 
         CRUD::field('initiativeCategory')->label('Select the initiative category.')
-            ->hint('Select the one that best matches. If none of the options fit, select "other".')
-            // add CSS class "form-group", background color changed to pink at the beginning, then it changed back to white.
-            // it proved that CSS classs can be applied to a specific form field
-            //
-            // add a CSS class to change background color of this form field.
-            // Note:
-            // 1. Background color applied to the background of select2 instead of select2 itself... Field label background has been changed too
-            // 2. CSS class bg-danger-subtle (i.e. pink color) is not available until Bootstrap v5.3 (we are not using Bootstrap v5.3 yet...)
-            //
-            // ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
-        ;
+            ->hint('Select the one that best matches. If none of the options fit, select "other".');
 
 
         CRUD::field('initiative_category_other')->label('Enter the "other" category of initiative.');
@@ -357,12 +347,7 @@ class ProjectCrudController extends CrudController
             ->options([
                 0 => 'This initiative is <b>entirely</b> self-funded',
                 1 => 'This initiative has external funding sources',
-            ])
-            // add a CSS class to change background color of this form field.
-            // Note:
-            // 1. Background color applied to whole part of radio button, instead of radio button options only
-            // ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
-        ;
+            ]);
 
         CRUD::field('fundingSources')
             ->label('Funding Sources')

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -204,7 +204,8 @@ class ProjectCrudController extends CrudController
             // 1. Background color applied to the background of select2 instead of select2 itself... Field label background has been changed too
             // 2. CSS class bg-danger-subtle (i.e. pink color) is not available until Bootstrap v5.3 (we are not using Bootstrap v5.3 yet...)
             //
-            ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
+            // ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
+        ;
 
 
         CRUD::field('initiative_category_other')->label('Enter the "other" category of initiative.');
@@ -360,7 +361,8 @@ class ProjectCrudController extends CrudController
             // add a CSS class to change background color of this form field.
             // Note:
             // 1. Background color applied to whole part of radio button, instead of radio button options only
-            ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
+            // ->wrapper(['class' => 'form-group col-sm-12 bg-danger']);
+        ;
 
         CRUD::field('fundingSources')
             ->label('Funding Sources')

--- a/resources/sass/_backpack-form-tweaks.scss
+++ b/resources/sass/_backpack-form-tweaks.scss
@@ -42,17 +42,39 @@ form .form-group.required>select {
 
 
 
+
+
+
+// TODO: change background color for required select2 selection box
+span.select2-selection__rendered {
+  background-color: pink;
+}
+
+
+
+
+
+
+
 // TODO: change background color for required checkbox field
 form .form-group.required>checkbox {
   background-color: pink;
 }
 
-// TODO: change background color for required select2 selection box
-form .form-group.required>select2 {
+
+
+
+// change background color for label of all radio buttons, no matter it is a required field or not
+// Note: it affects the Yes button and No button in Red Flag Assessment form
+form .form-check>input[type="radio"]+label {
   background-color: pink;
 }
 
-// TODO: change background color for required radio button
-form .form-group.required>radio {
-  background-color: pink;
+
+
+
+// TODO: change background color for label of all required radio buttons
+// Question: why it does not work...?
+form .form-check.required>input[type="radio"]+label {
+  background-color: lightgreen;
 }

--- a/resources/sass/_backpack-form-tweaks.scss
+++ b/resources/sass/_backpack-form-tweaks.scss
@@ -19,10 +19,19 @@
   }
 }
 
-form .form-group.required>label:not(:empty):not(.form-check-label)::after {
+form .form-group.required>label:not(:empty):not(.form-check-label)::before {
   color: red;
-  content: " *";
+  content: "* ";
 }
+
+
+form .form-group.required>label:not(:empty):not(.form-check-label) {
+  background-color: lightgreen;
+}
+
+
+
+/*
 
 // change background color for required text field
 form .form-group.required>input {
@@ -43,7 +52,7 @@ form .form-group.required>select {
   background-color: pink;
 }
 
-
+*/
 
 
 
@@ -62,6 +71,9 @@ span.select2-selection__rendered {
 */
 
 
+
+/*
+
 span.select2-hidden-accessible {
   background-color: green;
 }
@@ -76,3 +88,6 @@ span.select2-hidden-accessible {
 form .form-check>input[type="radio"]+label {
   background-color: pink;
 }
+
+
+*/

--- a/resources/sass/_backpack-form-tweaks.scss
+++ b/resources/sass/_backpack-form-tweaks.scss
@@ -34,7 +34,11 @@ form .form-group.required>textarea {
   background-color: pink;
 }
 
+
 // change background color for required selection box
+// Note:
+// 1. it changes background color of normal selection box
+// 2. it changes select2 background color at the beginning after loading page, then select2 background color changed back to white
 form .form-group.required>select {
   background-color: pink;
 }
@@ -44,37 +48,31 @@ form .form-group.required>select {
 
 
 
+/*
 
 // TODO: change background color for required select2 selection box
+// Note:
+// 1. it applies to select2 drop down selection box only
+// 2. it changes the background color of select2 inner part instead of the whole select2 selection box
+// 3. select2 options background color does not change (do the same for CSS class for select2 options?)
 span.select2-selection__rendered {
   background-color: pink;
 }
 
+*/
 
 
-
-
-
-
-// TODO: change background color for required checkbox field
-form .form-group.required>checkbox {
-  background-color: pink;
+span.select2-hidden-accessible {
+  background-color: green;
 }
 
 
 
 
-// change background color for label of all radio buttons, no matter it is a required field or not
-// Note: it affects the Yes button and No button in Red Flag Assessment form
+// change background color for radio button options label
+// Note:
+// 1. it affects the Yes button and No button in Red Flag Assessment form
+// 2. it affects all radio button options label, no matter it is a required field or not
 form .form-check>input[type="radio"]+label {
   background-color: pink;
-}
-
-
-
-
-// TODO: change background color for label of all required radio buttons
-// Question: why it does not work...?
-form .form-check.required>input[type="radio"]+label {
-  background-color: lightgreen;
 }

--- a/resources/sass/_backpack-form-tweaks.scss
+++ b/resources/sass/_backpack-form-tweaks.scss
@@ -19,75 +19,18 @@
   }
 }
 
+// show the red * AFTER field label instead of BEFORE field label
 form .form-group.required>label:not(:empty):not(.form-check-label)::before {
   color: red;
   content: "* ";
 }
 
-
-form .form-group.required>label:not(:empty):not(.form-check-label) {
-  background-color: lightgreen;
+// change border of all form fields
+form .form-group .form-control {
+  border: 1px solid black !important;
 }
 
-
-
-/*
-
-// change background color for required text field
-form .form-group.required>input {
-  background-color: pink;
+// change border of select2
+span.select2 {
+  border: 1px solid black !important;
 }
-
-// change background color for required textarea field
-form .form-group.required>textarea {
-  background-color: pink;
-}
-
-
-// change background color for required selection box
-// Note:
-// 1. it changes background color of normal selection box
-// 2. it changes select2 background color at the beginning after loading page, then select2 background color changed back to white
-form .form-group.required>select {
-  background-color: pink;
-}
-
-*/
-
-
-
-
-/*
-
-// TODO: change background color for required select2 selection box
-// Note:
-// 1. it applies to select2 drop down selection box only
-// 2. it changes the background color of select2 inner part instead of the whole select2 selection box
-// 3. select2 options background color does not change (do the same for CSS class for select2 options?)
-span.select2-selection__rendered {
-  background-color: pink;
-}
-
-*/
-
-
-
-/*
-
-span.select2-hidden-accessible {
-  background-color: green;
-}
-
-
-
-
-// change background color for radio button options label
-// Note:
-// 1. it affects the Yes button and No button in Red Flag Assessment form
-// 2. it affects all radio button options label, no matter it is a required field or not
-form .form-check>input[type="radio"]+label {
-  background-color: pink;
-}
-
-
-*/

--- a/resources/sass/_backpack-form-tweaks.scss
+++ b/resources/sass/_backpack-form-tweaks.scss
@@ -1,26 +1,26 @@
-
 .full-width-choices .select2-selection__choice {
-    width: 85%;
-    padding-top: 0.5em !important;
-    padding-bottom: 0.5em !important;
-    font-size: medium;
-    border-radius: 0.5em;
-    padding-left: 0 !important;
-    white-space:  normal;
-    word-wrap: break-word;
+  width: 85%;
+  padding-top: 0.5em !important;
+  padding-bottom: 0.5em !important;
+  font-size: medium;
+  border-radius: 0.5em;
+  padding-left: 0 !important;
+  white-space: normal;
+  word-wrap: break-word;
 
-    .select2-selection__choice__remove {
-        padding-left: 1em;
-        padding-right: 1em;
-        top: -0.5em !important;
-        position: relative;
-        margin-right: 1em !important;
-        background-color: lightgrey;
-        border-right: grey;
-    }
+  .select2-selection__choice__remove {
+    padding-left: 1em;
+    padding-right: 1em;
+    top: -0.5em !important;
+    position: relative;
+    margin-right: 1em !important;
+    background-color: lightgrey;
+    border-right: grey;
+  }
 }
 
-form .form-group.required > label:not(:empty):not(.form-check-label)::after {
+form .form-group.required>label:not(:empty):not(.form-check-label)::after {
   color: red;
   content: " *";
+  background-color: lightyellow;
 }

--- a/resources/sass/_backpack-form-tweaks.scss
+++ b/resources/sass/_backpack-form-tweaks.scss
@@ -22,5 +22,37 @@
 form .form-group.required>label:not(:empty):not(.form-check-label)::after {
   color: red;
   content: " *";
-  background-color: lightyellow;
+}
+
+// change background color for required text field
+form .form-group.required>input {
+  background-color: pink;
+}
+
+// change background color for required textarea field
+form .form-group.required>textarea {
+  background-color: pink;
+}
+
+// change background color for required selection box
+form .form-group.required>select {
+  background-color: pink;
+}
+
+
+
+
+// TODO: change background color for required checkbox field
+form .form-group.required>checkbox {
+  background-color: pink;
+}
+
+// TODO: change background color for required select2 selection box
+form .form-group.required>select2 {
+  background-color: pink;
+}
+
+// TODO: change background color for required radio button
+form .form-group.required>radio {
+  background-color: pink;
 }


### PR DESCRIPTION
This PR is submitted to fix #276 

It is not yet ready for review. It is submitted for progress review.

---

As per our discussion this morning, there are 2 approaches. We will go for approach 2.
1. Change background color of all required fields in all forms. Including portfolio creation, project creation, principle assessment, etc.
2. Find CSS class for required field, update CSS class to have light yellow background color. So that all required fields will have different background color by one change.

---

This PR contains below changes:
 - [x] Find CSS class name for required fields. The CSS class name is "required"
 - [ ] Update CSS class for light yellow background color for required fields

---

This PR is revised to contain below changes now:
 - [x] Move the red star BEFORE field label instead of AFTER field label
 - [x] Increase border width to 1px of all input fields
    - [x] textbox, textarea, select
    - [x] radio button and checkbox have a thick enough border, they are obvious already
    - [x] select2 component (refer to https://select2.org/configuration/options-api)
