### PR TITLE
add has_all_countries to projects

### DIFF
--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -49,7 +49,7 @@ class ProjectRequest extends FormRequest
             'geographic_reach' => ['required', Rule::in(collect(GeographicalReach::cases())->pluck('value')->toArray())],
             'continents' => 'required',
             'regions' => 'required',
-            'countries' => 'required',
+            'countries' => 'required_if:has_all_countries,0',
             'sub_regions' => 'nullable'
         ];
     }
@@ -75,6 +75,7 @@ class ProjectRequest extends FormRequest
     {
         return [
             'displayBudget.required' => 'The budget field is required.',
+            'countries.required_if' => 'The countries field is required if "has all countries" is not ticked.'
         ];
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -30,6 +30,7 @@ Project extends Model
     protected $casts = [
         'start_date' => 'date',
         'end_date' => 'date',
+        'has_all_countries' => 'boolean',
     ];
 
     protected static function booted()

--- a/database/migrations/2025_01_09_104742_add_has_all_countries_to_projects_table.php
+++ b/database/migrations/2025_01_09_104742_add_has_all_countries_to_projects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->boolean('has_all_countries')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('has_all_countries');
+        });
+    }
+};

--- a/public/assets/js/admin/forms/project_create.js
+++ b/public/assets/js/admin/forms/project_create.js
@@ -120,3 +120,15 @@ checkInitiativeCategoryOtherField();
 crud.field('initiativeCategory').onChange(function (field) {
     checkInitiativeCategoryOtherField()
 })
+
+
+// *********** Handle All Country Checkbox
+
+crud.field('has_all_countries').onChange(function (field) {
+    if (field.value == 1) {
+        crud.field('countries').disable();
+    } else {
+        crud.field('countries').enable();
+    }
+
+}).change()


### PR DESCRIPTION
Work in Progress:

fixes #277; 


Adds 'has_all_countries' to project. In project editing, adds a checkbox to toggle that property. On save, if has_all_countries===true, every country in the selected regions is added to the project. 

TODO: add 'has_all_regions' to project. 

