### PR TITLE
Improve Principle Assessment UI

### DIFF
--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -161,7 +161,7 @@ const assessment = computed(() => props.principleAssessment.assessment ?? null)
 const has_rating = computed(() => props.principleAssessment.rating !== null || props.principleAssessment.is_na)
 
 // for user to enter new score tag
-const newCustomTag = ref([])
+const newCustomTag = ref('')
 
 // score tags
 const tagNameRefs = ref([])
@@ -172,9 +172,8 @@ function addCustomScoreTag() {
         description: '',
     })
 
-    const index = props.principleAssessment.custom_score_tags.length - 1;
+    newCustomTag.value = '';
 
-    nextTick(() => tagNameRefs.value[index].focus());
 }
 
 function removeCustomScoreTag(index) {

--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -102,12 +102,13 @@
                             <div class="d-flex form-group">
 
                                 <v-text-field
-                                    ref="temp"
+                                    v-model="newCustomTag"
                                     label="Enter a descriptive name for the example / indicator"
                                     density="compact"
                                     variant="underlined"
                                     append-icon="mdi-plus-circle"
-                                    @click:append="addCustomScoreTagWithScoreTagName()"
+                                    @click:append="addCustomScoreTag"
+                                    @keydown.enter="addCustomScoreTag"
                                 />
                             </div>
 
@@ -127,18 +128,6 @@
                                     @click:append="removeCustomScoreTag(index)"
                                 />
                             </div>
-
-                            <!-- TODO: remove it -->
-                            <!--
-                            <button class="btn btn-secondary" @click="addCustomScoreTag">
-                                <i class="la la-plus"></i> Add New Example
-                            </button>
-                            -->
-
-                            <!-- TODO: remove it, it is for testing -->
-                            <button class="btn btn-secondary" @click="addCustomScoreTagWithScoreTagName('abc')">
-                                <i class="la la-plus"></i> Add New Example
-                            </button>
 
                         </div>
 
@@ -165,49 +154,28 @@ const props = defineProps({
     principleAssessment: Object,
     assessmentType: String,
     closing: Boolean,
-    // how to add props to extract form value?
-    temp: String,
 })
 
 const principle = computed(() => props.principleAssessment.principle ?? null)
 const assessment = computed(() => props.principleAssessment.assessment ?? null)
 const has_rating = computed(() => props.principleAssessment.rating !== null || props.principleAssessment.is_na)
 
-// TODO: how to extract form value?
-const temp = '123';
+// for user to enter new score tag
+const newCustomTag = ref([])
 
 // score tags
 const tagNameRefs = ref([])
 
 function addCustomScoreTag() {
     props.principleAssessment.custom_score_tags.push({
-        name: '',
+        name: newCustomTag.value,
         description: '',
     })
 
     const index = props.principleAssessment.custom_score_tags.length - 1;
 
-    nextTick(() => tagNameRefs.value[index].focus())
+    nextTick(() => tagNameRefs.value[index].focus());
 }
-
-function addCustomScoreTagWithScoreTagName(scoreTagName) {
-    alert(props.temp);
-
-    alert(scoreTagName);
-
-    return;
-
-
-    props.principleAssessment.custom_score_tags.push({
-        name: scoreTagName,
-        description: '',
-    })
-
-    const index = props.principleAssessment.custom_score_tags.length - 1;
-
-    nextTick(() => tagNameRefs.value[index].focus())
-}
-
 
 function removeCustomScoreTag(index) {
     console.log('hi', index)

--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -96,6 +96,23 @@
                             </div>
                         </div>
 
+                        <div>
+                            <p><b>Add new examples</b><br/>Type to add your own custom examples to support your rating. Click the + button or press Enter to add an example. You may add as many as you wish.</p>
+
+                            <div class="d-flex form-group">
+
+                                <v-text-field
+                                    ref="temp"
+                                    label="Enter a descriptive name for the example / indicator"
+                                    density="compact"
+                                    variant="underlined"
+                                    append-icon="mdi-plus-circle"
+                                    @click:append="addCustomScoreTagWithScoreTagName()"
+                                />
+                            </div>
+
+                        </div>
+
                         <div class="mt-8">
                             <div v-for="(tag, index) in principleAssessment.custom_score_tags" class="d-flex form-group">
 
@@ -105,14 +122,24 @@
                                     label="Enter a descriptive name for the example / indicator"
                                     density="compact"
                                     variant="underlined"
+                                    prepend-icon="mdi-check"
                                     append-icon="mdi-delete"
                                     @click:append="removeCustomScoreTag(index)"
                                 />
                             </div>
 
+                            <!-- TODO: remove it -->
+                            <!--
                             <button class="btn btn-secondary" @click="addCustomScoreTag">
                                 <i class="la la-plus"></i> Add New Example
                             </button>
+                            -->
+
+                            <!-- TODO: remove it, it is for testing -->
+                            <button class="btn btn-secondary" @click="addCustomScoreTagWithScoreTagName('abc')">
+                                <i class="la la-plus"></i> Add New Example
+                            </button>
+
                         </div>
 
                     </div>
@@ -138,11 +165,16 @@ const props = defineProps({
     principleAssessment: Object,
     assessmentType: String,
     closing: Boolean,
+    // how to add props to extract form value?
+    temp: String,
 })
 
 const principle = computed(() => props.principleAssessment.principle ?? null)
 const assessment = computed(() => props.principleAssessment.assessment ?? null)
 const has_rating = computed(() => props.principleAssessment.rating !== null || props.principleAssessment.is_na)
+
+// TODO: how to extract form value?
+const temp = '123';
 
 // score tags
 const tagNameRefs = ref([])
@@ -157,6 +189,25 @@ function addCustomScoreTag() {
 
     nextTick(() => tagNameRefs.value[index].focus())
 }
+
+function addCustomScoreTagWithScoreTagName(scoreTagName) {
+    alert(props.temp);
+
+    alert(scoreTagName);
+
+    return;
+
+
+    props.principleAssessment.custom_score_tags.push({
+        name: scoreTagName,
+        description: '',
+    })
+
+    const index = props.principleAssessment.custom_score_tags.length - 1;
+
+    nextTick(() => tagNameRefs.value[index].focus())
+}
+
 
 function removeCustomScoreTag(index) {
     console.log('hi', index)

--- a/resources/js/components/PrincipleAssessmentModal.vue
+++ b/resources/js/components/PrincipleAssessmentModal.vue
@@ -82,7 +82,9 @@
                         </div>
 
                         <div>
-                            <h5>Presence of Examples // Indicators <br/>for {{ principle.name }}</h5>
+                            <h5>Presence of Examples // Indicators
+                                <br/>for {{ principle.name }}
+                            </h5>
                             <p>Below are some common examples of {{ principle.name }} within a project. Tick the ones that are present within the project. You may also add additional examples below to further support the rating given.</p>
 
                             <div v-for="tag in principle.score_tags" class="checkbox-group mb-2 example-list">
@@ -94,33 +96,10 @@
                                     hide-details="auto"
                                 ></v-checkbox>
                             </div>
-                        </div>
-
-                        <div>
-                            <p><b>Add new examples</b><br/>Type to add your own custom examples to support your rating. Click the + button or press Enter to add an example. You may add as many as you wish.</p>
-
-                            <div class="d-flex form-group">
-
-                                <v-text-field
-                                    v-model="newCustomTag"
-                                    label="Enter a descriptive name for the example / indicator"
-                                    density="compact"
-                                    variant="underlined"
-                                    append-icon="mdi-plus-circle"
-                                    @click:append="addCustomScoreTag"
-                                    @keydown.enter="addCustomScoreTag"
-                                />
-                            </div>
-
-                        </div>
-
-                        <div class="mt-8">
-                            <div v-for="(tag, index) in principleAssessment.custom_score_tags" class="d-flex form-group">
-
+                            <div v-for="(tag, index) in principleAssessment.custom_score_tags" class="d-flex">
                                 <v-text-field
                                     ref="tagNameRefs"
                                     v-model="tag.name"
-                                    label="Enter a descriptive name for the example / indicator"
                                     density="compact"
                                     variant="underlined"
                                     prepend-icon="mdi-check"
@@ -128,6 +107,29 @@
                                     @click:append="removeCustomScoreTag(index)"
                                 />
                             </div>
+
+
+                            <div>
+                                <p>
+                                    <b>Add new examples</b><br/>Type to add your own custom examples to support your rating. Click the + button or press Enter to add an example. You may add as many as you wish.
+                                </p>
+
+                                <div class="d-flex form-group">
+
+                                    <v-text-field
+                                        ref="newTagRef"
+                                        v-model="newCustomTag"
+                                        label="Enter a descriptive name for the example / indicator"
+                                        density="compact"
+                                        variant="underlined"
+                                        append-icon="mdi-plus-circle"
+                                        @click:append="addCustomScoreTag"
+                                        @keydown.enter="addCustomScoreTag"
+                                    />
+                                </div>
+
+                            </div>
+
 
                         </div>
 
@@ -162,6 +164,7 @@ const has_rating = computed(() => props.principleAssessment.rating !== null || p
 
 // for user to enter new score tag
 const newCustomTag = ref('')
+const newTagRef = ref('');
 
 // score tags
 const tagNameRefs = ref([])
@@ -173,6 +176,13 @@ function addCustomScoreTag() {
     })
 
     newCustomTag.value = '';
+
+    nextTick(() => {
+        newTagRef.value.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+        })
+    })
 
 }
 
@@ -197,7 +207,7 @@ async function save(nextAction) {
         props.principleAssessment.rating = 0;
     }
 
-    if(props.principleAssessment.is_na) {
+    if (props.principleAssessment.is_na) {
         props.principleAssessment.rating = null;
     }
 


### PR DESCRIPTION
This PR is submitted to fix #170 

It is not yet ready for review. It is submitted for progress update.

After digesting Emily's suggestion, I tried to make a comprimise to minimize program change.

---

This PR should contain below changes:
 - [x] add a separate section with description for "Add new examples"
 - [x] adjust UI for adding new example, change "Add New Example" button to "+" button in green color
    - [x]  I do not change "+" button color to green. As "+" and "trash" button are both clickable, they should have same color
 - [x] adjust UI to show added examples with a tick in front of example name

---

TODO: review VueJS fundamentals

---

Screen shots:

![image](https://github.com/user-attachments/assets/e083d6f4-6ac4-4f6e-ab54-077fb4823ae8)
