### PR TITLE
Add Team Level Role

### DIFF
--- a/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
+++ b/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
@@ -32,7 +32,8 @@ class RegenerateTeamLevelRoleRecords extends Command
 
         $allOrganisations = Organisation::all();
 
-        $users = User::where('id', '=', 9)->with('roles')->get();
+        // $users = User::where('id', '=', 9)->with('roles')->get();
+        $users = User::with('roles')->get();
 
         foreach ($users as $user) {
             $this->comment($user->id . ' - ' . $user->name);
@@ -44,11 +45,10 @@ class RegenerateTeamLevelRoleRecords extends Command
             // Get the mininum role_id of user, suppose user can have one roles for any organisation currently
             $roles = DB::select('select min(role_id) as min_role_id from model_has_roles where model_id = ' . $user->id);
             $minRoleId = $roles[0]->min_role_id;
-            $this->comment(' ===> ' . $minRoleId);
+            $this->comment(' min_role_id ===> ' . $minRoleId);
 
             // Remove existing model_has_roles belong to user
             $deleteSql = "DELETE FROM model_has_roles WHERE model_id = " . $user->id;
-            ray($deleteSql);
             DB::statement($deleteSql);
 
             // Add role per user per organisations
@@ -57,7 +57,6 @@ class RegenerateTeamLevelRoleRecords extends Command
                 foreach ($allOrganisations as $organisation) {
                     $this->comment(' - ' . $organisation->name);
                     $insertSql = "INSERT INTO model_has_roles values ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
-                    ray($insertSql);
                     DB::statement($insertSql);
                 }
             } else {
@@ -65,12 +64,9 @@ class RegenerateTeamLevelRoleRecords extends Command
                 foreach ($user->organisations as $organisation) {
                     $this->comment(' - ' . $organisation->name);
                     $insertSql = "INSERT INTO model_has_roles values ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
-                    ray($insertSql);
                     DB::statement($insertSql);
                 }
             }
-
-            // TODO: need to check if it works by creating model_has_roles records by INSERT SQL
         }
 
         $this->info('end');

--- a/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
+++ b/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Models\Organisation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class RegenerateTeamLevelRoleRecords extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:regenerate-team-level-roles-records';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Regenerate team level roles records according to users, organisation_members and model_has_roles tables';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('start');
+
+        $allOrganisations = Organisation::all();
+
+        $users = User::where('id', '=', 9)->with('roles')->get();
+
+        foreach ($users as $user) {
+            $this->comment($user->id . ' - ' . $user->name);
+
+            // try to find user's role by using API but failed
+            // $this->comment(' ===> ' . $user->roles);
+            // $this->comment(' ===> ' . $user->getRoleNames());
+
+            // Get the mininum role_id of user, suppose user can have one roles for any organisation currently
+            $roles = DB::select('select min(role_id) as min_role_id from model_has_roles where model_id = ' . $user->id);
+            $minRoleId = $roles[0]->min_role_id;
+            $this->comment(' ===> ' . $minRoleId);
+
+            // Remove existing model_has_roles belong to user
+            $deleteSql = "DELETE FROM model_has_roles WHERE model_id = " . $user->id;
+            ray($deleteSql);
+            DB::statement($deleteSql);
+
+            // Add role per user per organisations
+            if ($minRoleId == 1 || $minRoleId == 2) {
+                // handling for Site Admin, Site Manager
+                foreach ($allOrganisations as $organisation) {
+                    $this->comment(' - ' . $organisation->name);
+                    $insertSql = "INSERT INTO model_has_roles values ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
+                    ray($insertSql);
+                    DB::statement($insertSql);
+                }
+            } else {
+                // handling for Ins Admin, Ins Assessor, Ins Member
+                foreach ($user->organisations as $organisation) {
+                    $this->comment(' - ' . $organisation->name);
+                    $insertSql = "INSERT INTO model_has_roles values ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
+                    ray($insertSql);
+                    DB::statement($insertSql);
+                }
+            }
+
+            // TODO: need to check if it works by creating model_has_roles records by INSERT SQL
+        }
+
+        $this->info('end');
+    }
+}

--- a/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
+++ b/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
@@ -43,7 +43,7 @@ class RegenerateTeamLevelRoleRecords extends Command
             // $this->comment(' ===> ' . $user->getRoleNames());
 
             // Get the mininum role_id of user, suppose user can have one roles for any organisation currently
-            $roles = DB::select('select min(role_id) as min_role_id from model_has_roles where model_id = ' . $user->id);
+            $roles = DB::select('SELECT MIN(role_id) AS min_role_id FROM model_has_roles WHERE model_id = ' . $user->id);
             $minRoleId = $roles[0]->min_role_id;
             $this->comment(' min_role_id ===> ' . $minRoleId);
 
@@ -56,14 +56,14 @@ class RegenerateTeamLevelRoleRecords extends Command
                 // handling for Site Admin, Site Manager
                 foreach ($allOrganisations as $organisation) {
                     $this->comment(' - ' . $organisation->name);
-                    $insertSql = "INSERT INTO model_has_roles values ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
+                    $insertSql = "INSERT INTO model_has_roles VALUES ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
                     DB::statement($insertSql);
                 }
             } else {
                 // handling for Ins Admin, Ins Assessor, Ins Member
                 foreach ($user->organisations as $organisation) {
                     $this->comment(' - ' . $organisation->name);
-                    $insertSql = "INSERT INTO model_has_roles values ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
+                    $insertSql = "INSERT INTO model_has_roles VALUES ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
                     DB::statement($insertSql);
                 }
             }

--- a/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
+++ b/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
@@ -42,7 +42,7 @@ class RegenerateTeamLevelRoleRecords extends Command
             // $this->comment(' ===> ' . $user->roles);
             // $this->comment(' ===> ' . $user->getRoleNames());
 
-            // Get the mininum role_id of user, suppose user can have one roles for any organisation currently
+            // Get the mininum role_id of user, suppose user can have one role for any organisation currently
             $roles = DB::select('SELECT MIN(role_id) AS min_role_id FROM model_has_roles WHERE model_id = ' . $user->id);
             $minRoleId = $roles[0]->min_role_id;
             $this->comment(' min_role_id ===> ' . $minRoleId);

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -30,12 +30,12 @@ class RegisteredUserController extends Controller
                 ->first();
         }
 
-        if(!$invite) {
+        if (!$invite) {
             abort(403, "It looks like the invitation token is invalid. Please contact the person who invited you to the platform and ask for a new invitation.");
         }
 
-        if($invite->is_confirmed) {
-           abort(403, "It looks like this invitation has already been used. If you have created an account, please <a href='" .url('login') . "'>login</a>. If you need a new invitation, please contact the person who sent you the invitation email.");
+        if ($invite->is_confirmed) {
+            abort(403, "It looks like this invitation has already been used. If you have created an account, please <a href='" . url('login') . "'>login</a>. If you need a new invitation, please contact the person who sent you the invitation email.");
         }
 
 
@@ -60,6 +60,8 @@ class RegisteredUserController extends Controller
             'email' => $request->email,
             'password' => Hash::make($request->password),
         ]);
+
+        // TODO: find code segment to create model_has_roles record, add orgnisation_id
 
         event(new Registered($user));
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,15 +2,17 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
+use App\Models\User;
 use App\Models\Invite;
 use App\Models\RoleInvite;
-use App\Models\User;
-use App\Providers\RouteServiceProvider;
-use Illuminate\Auth\Events\Registered;
+use App\Models\Organisation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Auth\Events\Registered;
+use App\Providers\RouteServiceProvider;
 
 class RegisteredUserController extends Controller
 {
@@ -61,7 +63,41 @@ class RegisteredUserController extends Controller
             'password' => Hash::make($request->password),
         ]);
 
-        // TODO: find code segment to create model_has_roles record, add orgnisation_id
+        // Note: model_has_roles record has been created at this point.
+        // It is good if we can pass in orgnisation_id for creating model_has_roles record.
+        // But it may take a long time to hack how does Spatie permissions pacakge create model_has_roles record.
+        //
+        // A quick workaround is to find the newly created model_has_roles record (it always has organisation_id as "1" for default value),
+        // then update organisation_id for institutional roles.
+        // For global roles, we will need to re-generate model_has_roles records for all organisations
+
+        // Get the mininum role_id of user, suppose user can have one role for any organisation currently
+        $roles = DB::select('SELECT MIN(role_id) AS min_role_id FROM model_has_roles WHERE model_id = ' . $user->id);
+        $minRoleId = $roles[0]->min_role_id;
+
+        if ($minRoleId == 1 || $minRoleId == 2) {
+            // Remove existing model_has_roles belong to user
+            $deleteSql = "DELETE FROM model_has_roles WHERE model_id = " . $user->id;
+            DB::statement($deleteSql);
+
+            // find all organisations
+            $allOrganisations = Organisation::all();
+
+
+            foreach ($allOrganisations as $organisation) {
+                // add model_has_roles records for all organisations
+                $insertSql = "INSERT INTO model_has_roles VALUES (" . $minRoleId . ", 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
+                DB::statement($insertSql);
+
+                // add organisation_member records for all organisations
+                $insertSql = "INSERT INTO organisation_members (user_id, organisation_id, role) VALUES (" . $user->id . ", " . $organisation->id . ", 'editor')";
+                DB::statement($insertSql);
+            }
+        } else {
+            // update organisation_id to model_has_roles record
+            $updateSql = "UPDATE model_has_roles SET organisation_id = " . $request->organisation_id . " WHERE model_id = " . $user->id;
+            DB::statement($updateSql);
+        }
 
         event(new Registered($user));
 

--- a/app/Http/Controllers/SelectedOrganisationController.php
+++ b/app/Http/Controllers/SelectedOrganisationController.php
@@ -15,9 +15,13 @@ class SelectedOrganisationController extends Controller
         $organisations = Organisation::orderBy('name')->get();
 
         // if only one organisation is available to the user, automatically select it (same as the middleware)
-        if($organisations->count() === 1) {
+        if ($organisations->count() === 1) {
             $orgId = $organisations->first()->id;
-            return redirect(backpack_url("organisation/$orgId/show"));
+            Session::put('selectedOrganisationId', $orgId);
+
+            $redirect = backpack_url('organisation/show');
+
+            return redirect($redirect);
         }
 
         return view('organisations.select', ['organisations' => $organisations]);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use App\Http\Middleware\EnsureOrganisationIsSelected;
+use App\Http\Middleware\SetOrgForPermissions;
 use App\Http\Middleware\SetProjectInSession;
 use App\Http\Middleware\TeamsPermission;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
@@ -70,5 +71,6 @@ class Kernel extends HttpKernel
         'org.selected' => EnsureOrganisationIsSelected::class,
         'project.set' => SetProjectInSession::class,
         'teams.permission' => TeamsPermission::class,
+        'set_org_for_permissions' => SetOrgForPermissions::class,
     ];
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,12 +38,14 @@ class Kernel extends HttpKernel
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
+            TeamsPermission::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
 
         'api' => [
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
+            TeamsPermission::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -45,7 +45,6 @@ class Kernel extends HttpKernel
         'api' => [
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
-            TeamsPermission::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Http;
 
 use App\Http\Middleware\EnsureOrganisationIsSelected;
 use App\Http\Middleware\SetProjectInSession;
+use App\Http\Middleware\TeamsPermission;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
@@ -67,5 +68,6 @@ class Kernel extends HttpKernel
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'org.selected' => EnsureOrganisationIsSelected::class,
         'project.set' => SetProjectInSession::class,
+        'teams.permission' => TeamsPermission::class,
     ];
 }

--- a/app/Http/Middleware/SetOrgForPermissions.php
+++ b/app/Http/Middleware/SetOrgForPermissions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Organisation;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetOrgForPermissions
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+
+        // temporarily set permissions ID to let admins and site managers access the site to choose an organisation
+        if (! getPermissionsTeamId()) {
+            setPermissionsTeamId(Organisation::withoutGLobalScope('owned')->first()->id);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/TeamsPermission.php
+++ b/app/Http/Middleware/TeamsPermission.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Middleware;
+
+class TeamsPermission
+{
+    public function handle($request, \Closure $next)
+    {
+        if (!empty(auth()->user())) {
+            // session value set on login
+            setPermissionsTeamId(session('selectedOrganisationId'));
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -44,11 +44,6 @@ class Organisation extends Model
                 return;
             }
 
-            // show all organisations if user is Site Admin
-            // if (Auth::user()?->isAdmin()) {
-            //     return;
-            // }
-
             if (Auth::user()?->can('view institutions')) {
                 return;
             }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -44,11 +44,6 @@ class Organisation extends Model
                 return;
             }
 
-            // temporarily set permissions ID to let admins and site managers access the site to choose an organisation
-            if (!getPermissionsTeamId()) {
-                setPermissionsTeamId(Organisation::first()->id);
-            }
-
             if (Auth::user()?->can('view institutions')) {
                 return;
             }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -200,6 +200,12 @@ class Organisation extends Model
                         'user_id' => $user->id,
                         'organisation_id' => $this->id,
                     ]);
+
+                    // add model_has_roles records, existing user will have a role to this institution immediately
+                    DB::insert(
+                        'insert into model_has_roles (role_id, model_type, model_id, organisation_id) values (?, ?, ?, ?)',
+                        [$roleId, 'App\\Models\\User', $user->id, $this->id]
+                    );
                 }
             }
         }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -46,7 +46,7 @@ class Organisation extends Model
 
             // temporarily set permissions ID to let admins and site managers access the site to choose an organisation
             if (!getPermissionsTeamId()) {
-                setPermissionsTeamId(1);
+                setPermissionsTeamId(Organisation::first()->id);
             }
 
             if (Auth::user()?->can('view institutions')) {

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -44,6 +44,11 @@ class Organisation extends Model
                 return;
             }
 
+            // show all organisations if user is Site Admin
+            // if (Auth::user()?->isAdmin()) {
+            //     return;
+            // }
+
             if (Auth::user()?->can('view institutions')) {
                 return;
             }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -61,6 +61,25 @@ class Organisation extends Model
                     ->update(['additional_status' => AssessmentStatus::NotStarted->value]);
             }
         });
+
+        // Add model_has_roles records for site admins and site managers when a new institution is created
+        static::created(function ($item) {
+            // add role for all Site Admin users
+            $siteAdmins = DB::select('SELECT DISTINCT model_id, role_id FROM model_has_roles WHERE role_id = 1');
+
+            foreach ($siteAdmins as $siteAdmin) {
+                $insertSql = "INSERT INTO model_has_roles VALUES (1, 'App\\\Models\\\User', " . $siteAdmin->model_id . ", " . $item->id . ")";
+                DB::statement($insertSql);
+            }
+
+            // add role for all Site Manager users
+            $siteManagers = DB::select('SELECT DISTINCT model_id, role_id FROM model_has_roles WHERE role_id = 2');
+
+            foreach ($siteManagers as $siteManager) {
+                $insertSql = "INSERT INTO model_has_roles VALUES (2, 'App\\\Models\\\User', " . $siteManager->model_id . ", " . $item->id . ")";
+                DB::statement($insertSql);
+            }
+        });
     }
 
 

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -33,7 +33,7 @@ class Organisation extends Model
 
     protected $casts = [
         'has_additional_criteria' => 'boolean',
-        'agreement_signed_at' => 'date'
+        'agreement_signed_at' => 'date',
     ];
 
     protected static function booted()
@@ -42,6 +42,11 @@ class Organisation extends Model
 
             if (!Auth::check()) {
                 return;
+            }
+
+            // temporarily set permissions ID to let admins and site managers access the site to choose an organisation
+            if (!getPermissionsTeamId()) {
+                setPermissionsTeamId(1);
             }
 
             if (Auth::user()?->can('view institutions')) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,10 +2,11 @@
 
 namespace App\Models;
 
-use Spatie\Permission\Models\Permission;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Models\Permission;
 use Illuminate\Database\Eloquent\Collection;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -66,7 +67,14 @@ class User extends Authenticatable
 
     public function isAdmin()
     {
+        // old approach: check if user has Site Admin role
         return $this->hasAnyRole('Site Admin');
+
+        // new approach: check if user has Site Admin role for any organisation
+        // $result = DB::select('SELECT COUNT(*) as record_count FROM model_has_roles WHERE role_id = 1 AND model_id = ' . auth()->user()->id);
+        // $recordCount = $result[0]->record_count;
+
+        // return $recordCount > 0;
     }
 
     public function withPermissionNames()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,14 +2,12 @@
 
 namespace App\Models;
 
-use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Models\Permission;
 use Illuminate\Database\Eloquent\Collection;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -67,14 +65,7 @@ class User extends Authenticatable
 
     public function isAdmin()
     {
-        // old approach: check if user has Site Admin role
         return $this->hasAnyRole('Site Admin');
-
-        // new approach: check if user has Site Admin role for any organisation
-        // $result = DB::select('SELECT COUNT(*) as record_count FROM model_has_roles WHERE role_id = 1 AND model_id = ' . auth()->user()->id);
-        // $recordCount = $result[0]->record_count;
-
-        // return $recordCount > 0;
     }
 
     public function withPermissionNames()

--- a/config/permission.php
+++ b/config/permission.php
@@ -82,6 +82,10 @@ return [
          */
 
         'model_morph_key' => 'model_id',
+
+        // use a custom foreign key for teams
+        // we use organisations as teams, the custom foreign key should be organisation_id
+        'team_foreign_key' => 'organisation_id',
     ],
 
     /*
@@ -140,4 +144,7 @@ return [
 
         'store' => 'default',
     ],
+
+    // to enable team level roles and permissions
+    'teams' => true,
 ];

--- a/database/migrations/2025_01_16_113418_add_teams_fields.php
+++ b/database/migrations/2025_01_16_113418_add_teams_fields.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\PermissionRegistrar;
+
+class AddTeamsFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+
+        if (! $teams) {
+            return;
+        }
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+        if (empty($columnNames['team_foreign_key'] ?? null)) {
+            throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        if (! Schema::hasColumn($tableNames['roles'], $columnNames['team_foreign_key'])) {
+            Schema::table($tableNames['roles'], function (Blueprint $table) use ($columnNames) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable()->after('id');
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+
+                $table->dropUnique('roles_name_guard_name_unique');
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            });
+        }
+
+        if (! Schema::hasColumn($tableNames['model_has_permissions'], $columnNames['team_foreign_key'])) {
+            Schema::table($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->default('1');
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->dropForeign([PermissionRegistrar::$pivotPermission]);
+                }
+                $table->dropPrimary();
+
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->foreign(PermissionRegistrar::$pivotPermission)
+                        ->references('id')->on($tableNames['permissions'])->onDelete('cascade');
+                }
+            });
+        }
+
+        if (! Schema::hasColumn($tableNames['model_has_roles'], $columnNames['team_foreign_key'])) {
+            Schema::table($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->default('1');;
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->dropForeign([PermissionRegistrar::$pivotRole]);
+                }
+                $table->dropPrimary();
+
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->foreign(PermissionRegistrar::$pivotRole)
+                        ->references('id')->on($tableNames['roles'])->onDelete('cascade');
+                }
+            });
+        }
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,8 +22,8 @@ class DatabaseSeeder extends Seeder
         $this->call(InitiativeCategorySeeder::class);
         $this->call(InstitutionTypeSeeder::class);
         $this->call(UserFeedbackTypeSeeder::class);
-        $this->call(TestSeeder::class);
         $this->call(DashboardRatingSeeder::class);
+        $this->call(TestSeeder::class);
         $this->call(ProjectSeeder::class);
         $this->call(ScoreTagsTableSeeder::class);
         $this->call(HelpTextEntrySeeder::class);

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -17,11 +17,27 @@ class TestSeeder extends Seeder
      */
     public function run()
     {
-        $user = User::factory()->create(['name' => 'Site Admin', 'email' => 'site_admin@example.com']);
-        $user->assignRole('Site Admin');
 
-        $user = User::factory()->create(['name' => 'Site Manager', 'email' => 'site_manager@example.com']);
-        $user->assignRole('Site Manager');
+        $institution = Organisation::create([
+            'name' => 'Test Institution 1',
+            'geographic_reach' => GeographicalReach::Global->value,
+            'currency' => 'EUR',
+            'has_additional_criteria' => 0,
+            'description' => 'This is a test organisation',
+        ]);
+
+
+        $admin = User::factory()->create(['name' => 'Site Admin', 'email' => 'site_admin@example.com']);
+        $manager = User::factory()->create(['name' => 'Site Manager', 'email' => 'site_manager@example.com']);
+
+
+        setPermissionsTeamId($institution->id);
+
+        $admin->assignRole('Site Admin');
+        $manager->assignRole('Site Manager');
+
+
+        // Add some test users to the test organisation
 
         $user1 = User::factory()->create(['name' => 'Institutional Admin', 'email' => 'ins_admin@example.com']);
         $user1->assignRole('Institutional Admin');
@@ -31,14 +47,6 @@ class TestSeeder extends Seeder
 
         $user3 = User::factory()->create(['name' => 'Institutional Member', 'email' => 'ins_member@example.com']);
         $user3->assignRole('Institutional Member');
-
-        $institution = Organisation::create([
-            'name' => 'Test Institution 1',
-            'geographic_reach' => GeographicalReach::Global->value,
-            'currency' => 'EUR',
-            'has_additional_criteria' => 0,
-            'description' => 'This is a test organisation',
-        ]);
 
         $portfolio = $institution->portfolios()->create([
             'name' => 'Test Portfolio 1',

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -80,17 +80,14 @@
                             </div>
                         </div>
 
-                        <!-- TODO: hide it -->
-                        <!--
+                        <!-- hide organisation_id in user registration form -->
                         <div class="form-group row">
                             <label class="col-md-4 col-form-label text-md-right"></label>
 
                             <div class="col-md-6">
-                                <input id='organisation_id' type="text" class="form-control" name="organisation_id" value="{{ $invite->organisation_id }}">
+                                <input id='organisation_id' type="hidden" class="form-control" name="organisation_id" value="{{ $invite->organisation_id }}">
                             </div>
                         </div>
-                        -->
-
 
                         <div class="form-group row mb-0">
                             <div class="col-md-6 offset-md-4">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -8,16 +8,16 @@
                 <div class="card-header">
                     <h3>{{ config('app.name') }}</h3>
                     Register
-                    </div>
+                </div>
 
                 <div class="card-body">
-                @if($invite)
-                        <div class="alert alert-info">
+                    @if($invite)
+                    <div class="alert alert-info">
 
-                            {{ $inviteMessage }}
-                            <br/><br/>
-                            Your invite is attached to your email address. Please use this same address when registering to get immediate access to the correct team/s and user permissions. You may change your email address after registration if you would prefer to use a different one.
-                        </div>
+                        {{ $inviteMessage }}
+                        <br /><br />
+                        Your invite is attached to your email address. Please use this same address when registering to get immediate access to the correct team/s and user permissions. You may change your email address after registration if you would prefer to use a different one.
+                    </div>
                     @endif
 
                     <form method="POST" action="{{ route('register') }}">
@@ -30,9 +30,9 @@
                                 <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
 
                                 @error('name')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
                                 @enderror
                             </div>
                         </div>
@@ -42,18 +42,18 @@
 
                             <div class="col-md-6">
                                 <input
-                                id="email"
-                                type="email"
-                                class="form-control @error('email') is-invalid @enderror"
-                                name="email"
-                                value="{{ old('email') ?: ($invite ? $invite->email : null )}}"
-                                required
-                                autocomplete="email">
+                                    id="email"
+                                    type="email"
+                                    class="form-control @error('email') is-invalid @enderror"
+                                    name="email"
+                                    value="{{ old('email') ?: ($invite ? $invite->email : null )}}"
+                                    required
+                                    autocomplete="email">
 
                                 @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
                                 @enderror
                             </div>
                         </div>
@@ -65,9 +65,9 @@
                                 <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
 
                                 @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
                                 @enderror
                             </div>
                         </div>
@@ -79,6 +79,18 @@
                                 <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
                             </div>
                         </div>
+
+                        <!-- TODO: hide it -->
+                        <!--
+                        <div class="form-group row">
+                            <label class="col-md-4 col-form-label text-md-right"></label>
+
+                            <div class="col-md-6">
+                                <input id='organisation_id' type="text" class="form-control" name="organisation_id" value="{{ $invite->organisation_id }}">
+                            </div>
+                        </div>
+                        -->
+
 
                         <div class="form-group row mb-0">
                             <div class="col-md-6 offset-md-4">

--- a/resources/views/vendor/backpack/base/inc/menu.blade.php
+++ b/resources/views/vendor/backpack/base/inc/menu.blade.php
@@ -5,8 +5,8 @@
 <ul class="nav navbar-nav d-md-down-none">
 
     @if (backpack_auth()->check())
-        <!-- Topbar. Contains the left part -->
-        @include(backpack_view('inc.topbar_left_content'))
+    <!-- Topbar. Contains the left part -->
+    @include(backpack_view('inc.topbar_left_content'))
     @endif
 
 </ul>
@@ -14,11 +14,11 @@
 
 <ul class="nav navbar-nav ml-auto mr-0 d-flex">
     <li class="nav-item mx-3 font-weight-bold"><a class="nav-link text-deep-green" href="{{ backpack_url('dashboard') }}">Dashboard</a>
-        </li>
+    </li>
     <li class="nav-item mx-3 font-weight-bold"><a class="nav-link text-deep-green" href="{{ backpack_url('organisation/show') }}">My Institution</a>
-        </li>
+    </li>
     <li class="nav-item mx-3 font-weight-bold"><a class="nav-link text-deep-green" href="{{ backpack_url('project') }}">Initiatives</a>
-        </li>
+    </li>
 </ul>
 
 
@@ -27,63 +27,60 @@
 <!-- ========================================================= -->
 <ul class="nav navbar-nav ml-auto mr-0">
     @if (backpack_auth()->guest())
-        <li class="nav-item"><a class="nav-link" href="{{ route('backpack.auth.login') }}">{{ trans('backpack::base.login') }}</a>
-        </li>
-        @if (config('backpack.base.registration_open'))
-            <li class="nav-item"><a class="nav-link" href="{{ route('backpack.auth.register') }}">{{ trans('backpack::base.register') }}</a></li>
-        @endif
+    <li class="nav-item"><a class="nav-link" href="{{ route('backpack.auth.login') }}">{{ trans('backpack::base.login') }}</a>
+    </li>
+    @if (config('backpack.base.registration_open'))
+    <li class="nav-item"><a class="nav-link" href="{{ route('backpack.auth.register') }}">{{ trans('backpack::base.register') }}</a></li>
+    @endif
     @else
-        <!-- Topbar. Contains the right part -->
-        @include(backpack_view('inc.topbar_right_content'))
+    <!-- Topbar. Contains the right part -->
+    @include(backpack_view('inc.topbar_right_content'))
 
 
-        <li class="nav-item pr-4">
-            <a class="nav-link d-flex justify-content-between align-items-center"
-               href="{{ backpack_url('support') }}"
-            >
-                <i class="la la-question-circle font-3xl pr-2"></i>
-                <span>Support</span>
-            </a>
-        </li>
+    <li class="nav-item pr-4">
+        <a class="nav-link d-flex justify-content-between align-items-center"
+            href="{{ backpack_url('support') }}">
+            <i class="la la-question-circle font-3xl pr-2"></i>
+            <span>Support</span>
+        </a>
+    </li>
 
-        <li class="nav-item pr-4">
-            <a class="nav-link d-flex justify-content-between align-items-center"
-               href="{{ route('backpack.account.info') }}"
-            >
-                <i class="la la-user-circle font-3xl pr-2"></i>
-                <span>My Account</span>
-            </a>
-        </li>
+    <li class="nav-item pr-4">
+        <a class="nav-link d-flex justify-content-between align-items-center"
+            href="{{ route('backpack.account.info') }}">
+            <i class="la la-user-circle font-3xl pr-2"></i>
+            <span>My Account</span>
+        </a>
+    </li>
 
-        @if(\App\Models\Organisation::count() > 1)
-        <li class="nav-item pr-4">
-            <a class="nav-link d-flex justify-content-between align-items-center"
-               href="{{ backpack_url('selected_organisation') }}"
-            >
-                <i class="la la-exclamation-circle font-3xl pr-2"></i>
-                <span>Change Institution</span>
-            </a>
-        </li>
-        @endif
+    @if(\App\Models\Organisation::count() > 1)
+    <li class="nav-item pr-4">
+        <a class="nav-link d-flex justify-content-between align-items-center"
+            href="{{ backpack_url('selected_organisation') }}">
+            <i class="la la-exclamation-circle font-3xl pr-2"></i>
+            <span>Change Institution</span>
+        </a>
+    </li>
+    @endif
 
-        @if(Auth::user()->can('maintain institutions'))
-        <li class="nav-item pr-4">
-            <a class="nav-link d-flex justify-content-between align-items-center"
-               href="{{ backpack_url('organisation-crud') }}"
-            >
-                <i class="la la-user-tie font-3xl pr-2"></i>
-                <span>Admin Panel</span>
-            </a>
-        </li>
-        @endif
+    <!-- TODO: change to if(Auth::user()->isAdmin()) -->
+    @if(Auth::user()->can('maintain institutions'))
+    <li class="nav-item pr-4">
+        <a class="nav-link d-flex justify-content-between align-items-center"
+            href="{{ backpack_url('organisation-crud') }}">
+            <i class="la la-user-tie font-3xl pr-2"></i>
+            <span>Admin Panel</span>
+        </a>
+    </li>
+    @endif
 
-        <!-- Logout button - tailored to use Laravel Breeze -->
-        <li class="nav-item pr-4">
-            <form method="POST" action={{ route('logout') }}>
+    <!-- Logout button - tailored to use Laravel Breeze -->
+    <li class="nav-item pr-4">
+        <form method="POST" action={{ route('logout') }}>
             @csrf
             <button class="btn btn-link text-dark" type="submit">{{ trans('backpack::base.logout') }}</button>
-            </form>
-        </li>
+        </form>
+    </li>
 
     @endif
 </ul>

--- a/resources/views/vendor/backpack/base/inc/menu.blade.php
+++ b/resources/views/vendor/backpack/base/inc/menu.blade.php
@@ -63,7 +63,6 @@
     </li>
     @endif
 
-    <!-- TODO: change to if(Auth::user()->isAdmin()) -->
     @if(Auth::user()->can('maintain institutions'))
     <li class="nav-item pr-4">
         <a class="nav-link d-flex justify-content-between align-items-center"

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -50,7 +50,8 @@ Route::group([
 
 ], function () { // custom admin routes
 
-    Route::get('selected_organisation', [SelectedOrganisationController::class, 'create']);
+    Route::get('selected_organisation', [SelectedOrganisationController::class, 'create'])
+    ->middleware(['set_org_for_permissions']);
     Route::post('selected_organisation', [SelectedOrganisationController::class, 'store']);
 
     Route::get('/', [SelectedOrganisationController::class, 'show']);

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -84,7 +84,7 @@ Route::group([
 
     // routes that require a selected organisation
     Route::group([
-        'middleware' => ['org.selected'],
+        'middleware' => ['org.selected', 'teams.permission'],
     ], function () {
 
         Route::get('organisation/show', [OrganisationController::class, 'show'])->name('organisation.self.show');
@@ -102,8 +102,9 @@ Route::group([
             return redirect("admin/organisation/show");
         })->name('portfolio.index');
 
-        Route::group([
-            'middleware' => ['project.set'],
+        Route::group(
+            [
+                'middleware' => ['project.set'],
             ],
             function () {
 
@@ -120,9 +121,8 @@ Route::group([
 
                 Route::post('project/{project}/generate-pdf', [GeneratePdfFileController::class, 'generateInitiativeSummary']);
                 Route::post('assessment/{assessment}/generate-pdf', [GeneratePdfFileController::class, 'generateAssessmentSummary']);
-
-
-            });
+            }
+        );
 
         Route::post('session/store', [SessionController::class, 'store']);
         Route::post('session/reset', [SessionController::class, 'reset']);


### PR DESCRIPTION
This PR is submitted to fix #242

It is not yet ready for review. It is submitted for progress update.

It should contain below changes:
 - [x] add new config items for team permissions in config/permission.php
 - [x] create migration files to add new team_foreign_key (i.e. organisation_id) in roles, model_has_roles, model_has_permissions tables
 - [x] add middleware to set session variable "selectedOrganisationId" as team id
 - [x] add middleware and middleware alias in Kernel.php
 - [x] add middleware to middleware groups in Kernel.php
 - [x] user registration, update organisation_id of existing model_has_roles record
 - [x] user registration, add roles to all organisations for Site Admin and Site Manager
 - [x] add model event created() to Organisation model, add role to the newly created organisation for all site admins and site managers
 - [x] develop a command program to generate model_has_roles records. One user should have N model_has_roles records if he belongs to N institutions