### PR TITLE
Fix Global Role Issues

### DIFF
--- a/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
+++ b/app/Console/Commands/RegenerateTeamLevelRoleRecords.php
@@ -59,6 +59,10 @@ class RegenerateTeamLevelRoleRecords extends Command
                     $insertSql = "INSERT INTO model_has_roles VALUES ($minRoleId, 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
                     DB::statement($insertSql);
                 }
+
+                // remove existing organisation_members record, global roles should not have organisation_members record
+                $deleteSql = "DELETE FROM organisation_members WHERE user_id = " . $user->id;
+                DB::statement($deleteSql);
             } else {
                 // handling for Ins Admin, Ins Assessor, Ins Member
                 foreach ($user->organisations as $organisation) {

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -88,10 +88,6 @@ class RegisteredUserController extends Controller
                 // add model_has_roles records for all organisations
                 $insertSql = "INSERT INTO model_has_roles VALUES (" . $minRoleId . ", 'App\\\Models\\\User', " . $user->id . ", " . $organisation->id . ")";
                 DB::statement($insertSql);
-
-                // add organisation_member records for all organisations
-                $insertSql = "INSERT INTO organisation_members (user_id, organisation_id, role) VALUES (" . $user->id . ", " . $organisation->id . ", 'editor')";
-                DB::statement($insertSql);
             }
         } else {
             // update organisation_id to model_has_roles record

--- a/app/Http/Middleware/EnsureOrganisationIsSelected.php
+++ b/app/Http/Middleware/EnsureOrganisationIsSelected.php
@@ -13,19 +13,21 @@ class EnsureOrganisationIsSelected
     public function handle(Request $request, Closure $next): Response
     {
 
-        if($request->session()->has('selectedOrganisationId')) {
+        if ($request->session()->has('selectedOrganisationId')) {
             return $next($request);
         }
 
         // if user has only 1 institution, select it and move on.
-        if(Organisation::count() === 1) {
+        if (Organisation::count() === 1) {
             Session::put('selectedOrganisationId', Organisation::first()->id);
-            return $next($request);
+
+            // tried to call setPermissionsTeamId() here, but problem persists.
+            // redirect user to My Institution page helps to load user's role, problem resolved.
+            return redirect(url('admin/organisation/show'));
         }
 
         Session::flash('redirect', $request->fullUrl());
 
         return redirect(backpack_url('selected_organisation'));
-
     }
 }

--- a/app/Http/Middleware/EnsureOrganisationIsSelected.php
+++ b/app/Http/Middleware/EnsureOrganisationIsSelected.php
@@ -21,11 +21,11 @@ class EnsureOrganisationIsSelected
         if (Organisation::count() === 1) {
             Session::put('selectedOrganisationId', Organisation::first()->id);
 
-            // tried to call setPermissionsTeamId() here, but problem persists.
-            // redirect user to My Institution page helps to load user's role, problem resolved.
-            return redirect(url('admin/organisation/show'));
+            // redirect to restart the entire request / middleware stack, so that the initial attempt to set the team for role/permission assignment can be done
+            return redirect($request->url());
         }
 
+        // For users with multiple institutions redirect them to select an organisation.
         Session::flash('redirect', $request->fullUrl());
 
         return redirect(backpack_url('selected_organisation'));

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -52,37 +52,44 @@ Route::group([
 ], function () { // custom admin routes
 
     Route::get('selected_organisation', [SelectedOrganisationController::class, 'create'])
-    ->middleware(['set_org_for_permissions']);
+        ->middleware(['set_org_for_permissions']);
     Route::post('selected_organisation', [SelectedOrganisationController::class, 'store']);
 
     Route::get('/', [SelectedOrganisationController::class, 'show']);
 
-    Route::crud('organisation-crud', OrganisationCrudController::class);
+
+    // for admin panel routes, find user's role (Site Admin or Site Manager) from any organisation is fine
+    Route::group([
+        'middleware' => ['set_org_for_permissions'],
+    ], function () {
+
+        Route::crud('organisation-crud', OrganisationCrudController::class);
+
+        Route::crud('red-flag', RedLineCrudController::class);
+        Route::crud('principle', PrincipleCrudController::class);
+        Route::crud('score-tag', ScoreTagCrudController::class);
+
+        Route::crud('user', UserCrudController::class);
+        Route::crud('role-invite', RoleInviteCrudController::class);
+
+        Route::crud('country', CountryCrudController::class);
+        Route::crud('continent', ContinentCrudController::class);
+        Route::crud('region', RegionCrudController::class);
 
 
-    Route::crud('red-flag', RedLineCrudController::class);
-    Route::crud('principle', PrincipleCrudController::class);
-    Route::crud('score-tag', ScoreTagCrudController::class);
+        Route::get('organisation-members', [OrganisationMemberController::class, 'show']);
 
-    Route::crud('user', UserCrudController::class);
-    Route::crud('role-invite', RoleInviteCrudController::class);
+        Route::get('organisation/{organisation}/members/create', [OrganisationMemberController::class, 'create'])->name('organisationmembers.create');
+        Route::post('organisation/{organisation}/members', [OrganisationMemberController::class, 'store'])->name('organisationmembers.store');
+        Route::get('organisation/{organisation}/members/{user}/edit', [OrganisationMemberController::class, 'edit'])->name('organisationmembers.edit');
+        Route::put('organisation/{organisation}/members/{user}', [OrganisationMemberController::class, 'update'])->name('organisationmembers.update');
+        Route::delete('organisation/{organisation}/members/{user}', [OrganisationMemberController::class, 'destroy'])->name('organisationmembers.destroy');
 
-    Route::crud('country', CountryCrudController::class);
-    Route::crud('continent', ContinentCrudController::class);
-    Route::crud('region', RegionCrudController::class);
+        Route::get('organisation/export-all', [OrganisationController::class, 'exportAll'])->name('organisation.export-all');
 
+        Route::get('organisation/export-merged', [OrganisationController::class, 'mergeAll']);
+    });
 
-    Route::get('organisation-members', [OrganisationMemberController::class, 'show']);
-
-    Route::get('organisation/{organisation}/members/create', [OrganisationMemberController::class, 'create'])->name('organisationmembers.create');
-    Route::post('organisation/{organisation}/members', [OrganisationMemberController::class, 'store'])->name('organisationmembers.store');
-    Route::get('organisation/{organisation}/members/{user}/edit', [OrganisationMemberController::class, 'edit'])->name('organisationmembers.edit');
-    Route::put('organisation/{organisation}/members/{user}', [OrganisationMemberController::class, 'update'])->name('organisationmembers.update');
-    Route::delete('organisation/{organisation}/members/{user}', [OrganisationMemberController::class, 'destroy'])->name('organisationmembers.destroy');
-
-    Route::get('organisation/export-all', [OrganisationController::class, 'exportAll'])->name('organisation.export-all');
-
-    Route::get('organisation/export-merged', [OrganisationController::class, 'mergeAll']);
 
     // routes that require a selected organisation
     Route::group([
@@ -170,7 +177,6 @@ Route::group([
         Route::crud('temp-project', TempProjectCrudController::class);
         Route::get('temp-project/finalise', [TempProjectCrudController::class, 'finalise']);
         Route::post('temp-project/discard-import', [TempProjectCrudController::class, 'discardImport'])->name('import.discard');
-
     });
 
 
@@ -186,7 +192,6 @@ Route::group([
     Route::crud('custom-score-tag', CustomScoreTagCrudController::class);
     Route::crud('help-text-entry', HelpTextEntryCrudController::class);
     Route::get('help-text-entry/find/{location}', [HelpTextEntryCrudController::class, 'find']);
-
 });
 Route::get('project/{id}/show-as-pdf', [ProjectCrudController::class, 'show'])
     ->middleware('auth.basic')


### PR DESCRIPTION
This PR is submitted to fix some global role issues.

It is not yet ready for review. It is submitted for progress update.

Some more issues for team-level roles found...

---

This PR contains below changes:
 - [x] one-time command program, delete organisation_members records for global roles
 - [x] user registration program, do not generate organisation_members records for global roles
 - [x] move "Admin Panel" in middleware "set_org_for_permissions". For global roles, it is fine to get user's role from any organisation
 - [x] for user belongs to one organisation, user's role is not loaded after login and selecting organisation automatically. Redirect to My Institution page can help to load user's role