### PR TITLE
Update Validation in project creation.

### DIFF
--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -376,6 +376,7 @@ class ProjectCrudController extends CrudController
             ]);
 
         CRUD::field('main_recipient')
+            ->type('textarea')
             ->label('Please enter the main recipient of the funds for this initiative')
             ->hint('E.g., the institution or entity that directly receives the majority of the funds for this initiative');
 

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -31,9 +31,9 @@ class ProjectRequest extends FormRequest
         return [
             'organisation_id' => 'required',
             'portfolio_id' => 'required',
-            'name' => 'required|string',
+            'name' => 'required|string|max:255',
             'code' => ['nullable', 'string', new UniqueProjectCode],
-            'description' => 'nullable|string',
+            'description' => 'nullable|string|max:5000',
             'initiativeCategory' => 'required|exists:initiative_categories,id',
             'initiative_category_other' => 'nullable',
             'budget' => 'required|integer|gte:0',
@@ -42,13 +42,16 @@ class ProjectRequest extends FormRequest
             // it is not necessary for project import
             // comment it temporary for testing
             // 'displayBudget' => ['required', new DisplayBudgetRule],
+            'fundingSources.*.source' => 'exclude_unless:uses_only_own_funds,1|required_without:fundingSources.*.institution_id',
+            'fundingSources.*.institution_id' => 'exclude_unless:uses_only_own_funds,1|required_without:fundingSources.*.source',
+            'fundingSources.*.amount' => 'exclude_unless:uses_only_own_funds,1|required|integer|gte:0',
 
             'currency' => 'required|max:3',
             'exchange_rate' => 'sometimes|required',
             'exchange_rate_eur' => 'sometimes|required',
             'uses_only_own_funds' => 'required|boolean',
             'main_recipient_id' => 'nullable',
-            'main_recipient' => 'required',
+            'main_recipient' => 'required|max:5000',
             'start_date' => 'required|date',
             'end_date' => 'nullable|after:start_date|date',
             'geographic_reach' => ['required', Rule::in(collect(GeographicalReach::cases())->pluck('value')->toArray())],
@@ -81,7 +84,10 @@ class ProjectRequest extends FormRequest
         return [
             'displayBudget.required' => 'The budget field is required.',
             'regions.required_if' => 'The regions field is required if "has all regions" is not ticked.',
-            'countries.required_if' => 'The countries field is required if "has all countries" is not ticked.'
+            'countries.required_if' => 'The countries field is required if "has all countries" is not ticked.',
+            'fundingSources.*.source.required_without' => 'For each funding source, please either select a source from the dropdown list or type in the name of the source.',
+            'fundingSources.*.institution_id.required_without' => 'For each funding source, please either select a source from the dropdown list or type in the name of the source.',
+            'fundingSources.*.amount' => 'Please enter a valid amount for all funding sources listed',
         ];
     }
 }

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -36,7 +36,7 @@ class ProjectRequest extends FormRequest
             'description' => 'nullable|string|max:5000',
             'initiativeCategory' => 'required|exists:initiative_categories,id',
             'initiative_category_other' => 'nullable',
-            'budget' => 'required|integer|gte:0|lt:2147483647',
+            'budget' => 'required|integer|gte:0|lte:2147483647',
 
             // displayBudget is required for manual adding initiative in front-end,
             // it is not necessary for project import
@@ -44,11 +44,11 @@ class ProjectRequest extends FormRequest
             // 'displayBudget' => ['required', new DisplayBudgetRule],
             'fundingSources.*.source' => 'exclude_unless:uses_only_own_funds,1|required_without:fundingSources.*.institution_id|max:255',
             'fundingSources.*.institution_id' => 'exclude_unless:uses_only_own_funds,1|required_without:fundingSources.*.source',
-            'fundingSources.*.amount' => 'exclude_unless:uses_only_own_funds,1|required|integer|gte:0|lt:2147483647',
+            'fundingSources.*.amount' => 'exclude_unless:uses_only_own_funds,1|required|integer|gte:0|lte:2147483647',
 
             'currency' => 'required|max:3',
-            'exchange_rate' => 'sometimes|required|gte:0|lt:2147483647',
-            'exchange_rate_eur' => 'sometimes|required|gte:0|lt:2147483647',
+            'exchange_rate' => 'sometimes|required|gte:0|lte:2147483647',
+            'exchange_rate_eur' => 'sometimes|required|gte:0|lte:2147483647',
             'uses_only_own_funds' => 'required|boolean',
             'main_recipient_id' => 'nullable',
             'main_recipient' => 'required|max:5000',

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -32,7 +32,7 @@ class ProjectRequest extends FormRequest
             'organisation_id' => 'required',
             'portfolio_id' => 'required',
             'name' => 'required|string|max:255',
-            'code' => ['nullable', 'string', new UniqueProjectCode],
+            'code' => ['nullable', 'string', new UniqueProjectCode, 'max:255'],
             'description' => 'nullable|string|max:5000',
             'initiativeCategory' => 'required|exists:initiative_categories,id',
             'initiative_category_other' => 'nullable',

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -36,19 +36,19 @@ class ProjectRequest extends FormRequest
             'description' => 'nullable|string|max:5000',
             'initiativeCategory' => 'required|exists:initiative_categories,id',
             'initiative_category_other' => 'nullable',
-            'budget' => 'required|integer|gte:0',
+            'budget' => 'required|integer|gte:0|lt:2147483647',
 
             // displayBudget is required for manual adding initiative in front-end,
             // it is not necessary for project import
             // comment it temporary for testing
             // 'displayBudget' => ['required', new DisplayBudgetRule],
-            'fundingSources.*.source' => 'exclude_unless:uses_only_own_funds,1|required_without:fundingSources.*.institution_id',
+            'fundingSources.*.source' => 'exclude_unless:uses_only_own_funds,1|required_without:fundingSources.*.institution_id|max:255',
             'fundingSources.*.institution_id' => 'exclude_unless:uses_only_own_funds,1|required_without:fundingSources.*.source',
-            'fundingSources.*.amount' => 'exclude_unless:uses_only_own_funds,1|required|integer|gte:0',
+            'fundingSources.*.amount' => 'exclude_unless:uses_only_own_funds,1|required|integer|gte:0|lt:2147483647',
 
             'currency' => 'required|max:3',
-            'exchange_rate' => 'sometimes|required',
-            'exchange_rate_eur' => 'sometimes|required',
+            'exchange_rate' => 'sometimes|required|gte:0|lt:2147483647',
+            'exchange_rate_eur' => 'sometimes|required|gte:0|lt:2147483647',
             'uses_only_own_funds' => 'required|boolean',
             'main_recipient_id' => 'nullable',
             'main_recipient' => 'required|max:5000',

--- a/database/migrations/2025_03_04_125842_make_main_recipient_text_in_projects_table.php
+++ b/database/migrations/2025_03_04_125842_make_main_recipient_text_in_projects_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->text('main_recipient')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
This PR fixes #310, and makes some updates to validate the funding sources. (Fixes #295).

- Updates `projects.main_recipient` to be a text instead of varchar;

- Adds validation rules for the 3 fields inside the "fundingSources" relationship repeater. 
- adds a max-character validation to `main_recipient`, `name`, `code`, `description`, `fundingSources.*.source`
- adds max int value validation (just for completeness).

